### PR TITLE
fix(validation): handle trailing slashes in path checks and add tests

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -144,10 +144,20 @@ export function parseCommand(fullCommand: string): { command: string; args: stri
 }
 
 export function isPathAllowed(testPath: string, allowedPaths: string[]): boolean {
-    const normalizedPath = path.normalize(testPath).toLowerCase();
+    // Ensure consistent path format without trailing slash
+    const normalizedPath = path.normalize(testPath)
+        .toLowerCase()
+        .replace(/\\$/, ''); // Remove trailing backslash if present
+    
     return allowedPaths.some(allowedPath => {
-        const normalizedAllowedPath = path.normalize(allowedPath).toLowerCase();
-        return normalizedPath.startsWith(normalizedAllowedPath);
+        // Ensure consistent path format without trailing slash for allowed paths too
+        const normalizedAllowedPath = path.normalize(allowedPath)
+            .toLowerCase()
+            .replace(/\\$/, ''); // Remove trailing backslash if present
+            
+        // Check if test path starts with allowed path
+        return normalizedPath === normalizedAllowedPath || 
+               normalizedPath.startsWith(normalizedAllowedPath + path.sep);
     });
 }
 

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -136,7 +136,7 @@ describe('Path Normalization', () => {
 
 describe('Allowed Paths Normalization', () => {
   test('removes duplicates and normalizes paths', () => {
-    const paths = ['C:/Test', 'c:\\test', '/c/Test'];
+    const paths = ['C:/Test', 'c:\\test', '/c/Test', 'C:\\test\\'];
     expect(normalizeAllowedPaths(paths)).toEqual(['c:\\test']);
   });
   test('removes nested subpaths', () => {
@@ -154,15 +154,41 @@ describe('Path Validation', () => {
   const allowedPaths = [
     'C:\\Users\\test',
     'D:\\Projects',
-    'C:\\Users\\Projects'
+    'C:\\Users\\Projects\\'
   ];
 
   test('isPathAllowed validates paths correctly', () => {
-    expect(isPathAllowed(normalizeWindowsPath('C:\\Users\\test\\docs'), allowedPaths)).toBe(true);
     expect(isPathAllowed(normalizeWindowsPath('C:\\Users\\test'), allowedPaths)).toBe(true);
-    expect(isPathAllowed(normalizeWindowsPath('/c/Users/Projects'), allowedPaths)).toBe(true);
+    expect(isPathAllowed(normalizeWindowsPath('C:\\Users\\test\\docs'), allowedPaths)).toBe(true);
     expect(isPathAllowed(normalizeWindowsPath('D:\\Projects\\code'), allowedPaths)).toBe(true);
+    expect(isPathAllowed(normalizeWindowsPath('/c/Users/Projects'), allowedPaths)).toBe(true);
     expect(isPathAllowed(normalizeWindowsPath('E:\\NotAllowed'), allowedPaths)).toBe(false);
+    expect(isPathAllowed(normalizeWindowsPath('C:\\Users\\Projects'), allowedPaths)).toBe(true);
+  });
+  
+  test('isPathAllowed handles trailing slashes correctly', () => {
+    // Test when allowedPath has trailing slash and input doesn't
+    // 'C:\Users\Projects\' is in allowedPaths with trailing slash
+    expect(isPathAllowed(normalizeWindowsPath('C:\\Users\\Projects'), allowedPaths)).toBe(true);
+    expect(isPathAllowed(normalizeWindowsPath('/c/Users/Projects'), allowedPaths)).toBe(true);
+    
+    // Test when allowedPath doesn't have trailing slash and input does
+    // 'D:\Projects' is in allowedPaths without trailing slash
+    expect(isPathAllowed(normalizeWindowsPath('D:\\Projects\\'), allowedPaths)).toBe(true);
+    expect(isPathAllowed(normalizeWindowsPath('/d/Projects/'), allowedPaths)).toBe(true);
+    
+    // Test when user path has trailing slash and allowed path doesn't
+    // 'C:\Users\test' is in allowedPaths without trailing slash
+    expect(isPathAllowed(normalizeWindowsPath('C:\\Users\\test\\'), allowedPaths)).toBe(true);
+    expect(isPathAllowed(normalizeWindowsPath('/c/Users/test/'), allowedPaths)).toBe(true);
+    
+    // Test with subdirectories when allowedPath has trailing slash
+    expect(isPathAllowed(normalizeWindowsPath('C:\\Users\\Projects\\subdir'), allowedPaths)).toBe(true);
+    expect(isPathAllowed(normalizeWindowsPath('/c/Users/Projects/subdir'), allowedPaths)).toBe(true);
+    
+    // Test with subdirectories when allowedPath doesn't have trailing slash
+    expect(isPathAllowed(normalizeWindowsPath('D:\\Projects\\subdir'), allowedPaths)).toBe(true);
+    expect(isPathAllowed(normalizeWindowsPath('/d/Projects/subdir'), allowedPaths)).toBe(true);
   });
 
   test('isPathAllowed is case insensitive', () => {


### PR DESCRIPTION
- Strip trailing backslashes from both allowed and input paths before comparison
- Update isPathAllowed to allow exact matches and nested paths regardless of trailing slashes
- Add unit tests covering all combinations of trailing‐slash scenarios for Windows and GitBash paths