### PR TITLE
feat: Add directory validation with GitBash path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,13 @@ The configuration file is divided into two main sections: `security` and `shells
   - Get the windows CLI server configuration
   - Returns the server configuration as a JSON string (excluding sensitive data)
 
+- **validate_directories**
+  - Check if specified directories are within allowed paths
+  - Only available when `restrictWorkingDirectory` is enabled in configuration
+  - Inputs:
+    - `directories` (array of strings): List of directory paths to validate
+  - Returns success message if all directories are valid, or error message detailing which directories are outside allowed paths
+
 ### Resources
 
 - **cli://config**

--- a/src/utils/directoryValidator.ts
+++ b/src/utils/directoryValidator.ts
@@ -1,0 +1,65 @@
+import path from 'path';
+import { normalizeWindowsPath, isPathAllowed } from './validation.js';
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Validates a list of directories against allowed paths
+ * @param directories List of directories to validate
+ * @param allowedPaths List of allowed paths
+ * @returns Object with validation result and error message if applicable
+ */
+export function validateDirectories(directories: string[], allowedPaths: string[]): { 
+  isValid: boolean; 
+  invalidDirectories: string[];
+} {
+  const invalidDirectories: string[] = [];
+  
+  // Normalize each directory and check if it's allowed
+  for (const dir of directories) {
+    try {
+      // Normalize the path to Windows format
+      const normalizedDir = normalizeWindowsPath(dir);
+      
+      // Check if the path is allowed
+      if (!isPathAllowed(normalizedDir, allowedPaths)) {
+        invalidDirectories.push(dir); // Store the original path for error reporting
+      }
+    } catch (error) {
+      // If normalization fails, consider the directory invalid
+      invalidDirectories.push(dir);
+    }
+  }
+  
+  return {
+    isValid: invalidDirectories.length === 0,
+    invalidDirectories
+  };
+}
+
+/**
+ * Validates directories and throws an error if any are not allowed
+ * @param directories List of directories to validate
+ * @param allowedPaths List of allowed paths
+ * @throws McpError if any directory is not allowed
+ */
+export function validateDirectoriesAndThrow(directories: string[], allowedPaths: string[]): void {
+  const result = validateDirectories(directories, allowedPaths);
+  
+  if (!result.isValid) {
+    const invalidDirsStr = result.invalidDirectories.join(', ');
+    const allowedPathsStr = allowedPaths.join(', ');
+    
+    // If one invalid directory is found, throw an error
+    if (result.invalidDirectories.length === 1) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `The following directory is outside allowed paths: ${invalidDirsStr}. Allowed paths are: ${allowedPathsStr}. Commands with restricted directory is not allowed to execute.`
+      );
+    } else {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `The following directories are outside allowed paths: ${invalidDirsStr}. Allowed paths are: ${allowedPathsStr}. Commands with restricted directories are not allowed to execute.`
+      );
+    }
+  }
+}

--- a/src/utils/toolDescription.ts
+++ b/src/utils/toolDescription.ts
@@ -11,6 +11,7 @@ export function buildToolDescription(allowedShells: string[]): string[] {
     "1. Request config of this MCP server configuration using tools",
     "2. Follow limitations taken from configuration",
     "3. Use workingDir parameter for command based on task description",
+    "4. Use validate_directories tool to validate directories before execution",
     ""
   ];
 

--- a/tests/directoryValidator.test.ts
+++ b/tests/directoryValidator.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test, jest } from '@jest/globals';
+import {
+  validateDirectories,
+  validateDirectoriesAndThrow
+} from '../src/utils/directoryValidator.js';
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+
+// Mock the validation.js functions that directoryValidator.js depends on
+jest.mock('../src/utils/validation.js', () => ({
+  normalizeWindowsPath: jest.fn((path: string): string => {
+    // Simple mock implementation for path normalization
+    if (path.startsWith('/c/')) {
+      return 'C:' + path.substring(2).replace(/\//g, '\\');
+    }
+    if (path.includes('/')) {
+      return path.replace(/\//g, '\\');
+    }
+    return path;
+  }),
+  isPathAllowed: jest.fn((path: string, allowedPaths: string[]): boolean => {
+    // Mock implementation to check if path is within allowed paths
+    for (const allowedPath of allowedPaths) {
+      if (path.toLowerCase().startsWith(allowedPath.toLowerCase())) {
+        return true;
+      }
+    }
+    return false;
+  })
+}));
+
+describe('Directory Validator', () => {
+  // Define test allowed paths
+  const allowedPaths = ['C:\\Users\\test', 'D:\\Projects'];
+
+  describe('validateDirectories', () => {
+    test('should return valid for directories within allowed paths', () => {
+      const directories = ['C:\\Users\\test\\docs', 'D:\\Projects\\web'];
+      const result = validateDirectories(directories, allowedPaths);
+      
+      expect(result.isValid).toBe(true);
+      expect(result.invalidDirectories).toHaveLength(0);
+    });
+
+    test('should return invalid for directories outside allowed paths', () => {
+      const directories = ['C:\\Windows\\System32', 'E:\\NotAllowed'];
+      const result = validateDirectories(directories, allowedPaths);
+      
+      expect(result.isValid).toBe(false);
+      expect(result.invalidDirectories).toEqual(directories);
+    });
+
+    test('should handle a mix of valid and invalid directories', () => {
+      const validDir = 'C:\\Users\\test\\documents';
+      const invalidDir = 'C:\\Program Files';
+      const directories = [validDir, invalidDir];
+      
+      const result = validateDirectories(directories, allowedPaths);
+      
+      expect(result.isValid).toBe(false);
+      expect(result.invalidDirectories).toContain(invalidDir);
+      expect(result.invalidDirectories).not.toContain(validDir);
+    });
+
+    test('should handle GitBash style paths', () => {
+      const directories = ['/c/Users/test/docs', '/d/Projects/web'];
+      const result = validateDirectories(directories, allowedPaths);
+      
+      expect(result.isValid).toBe(true);
+      expect(result.invalidDirectories).toHaveLength(0);
+    });
+
+    test('should consider invalid paths that throw during normalization', () => {
+      // Mock normalizeWindowsPath to throw for a specific path
+      const validationModule = jest.requireMock('../src/utils/validation.js') as { normalizeWindowsPath: jest.Mock };
+      validationModule.normalizeWindowsPath.mockImplementationOnce(() => {
+        throw new Error('Invalid path format');
+      });
+      
+      const directories = ['invalid://path', 'D:\\Projects\\web'];
+      const result = validateDirectories(directories, allowedPaths);
+      
+      expect(result.isValid).toBe(false);
+      expect(result.invalidDirectories).toContain('invalid://path');
+    });
+  });
+
+  describe('validateDirectoriesAndThrow', () => {
+    test('should not throw for valid directories', () => {
+      const directories = ['C:\\Users\\test\\docs', 'D:\\Projects\\web'];
+      
+      expect(() => {
+        validateDirectoriesAndThrow(directories, allowedPaths);
+      }).not.toThrow();
+    });
+
+    test('should throw McpError for invalid directories', () => {
+      const directories = ['C:\\Windows\\System32', 'E:\\NotAllowed'];
+      
+      expect(() => {
+        validateDirectoriesAndThrow(directories, allowedPaths);
+      }).toThrow(McpError);
+    });
+
+    test('should include invalid directories in error message', () => {
+      const invalidDir1 = 'C:\\Windows\\System32';
+      const invalidDir2 = 'E:\\NotAllowed';
+      const directories = [invalidDir1, invalidDir2];
+      
+      try {
+        validateDirectoriesAndThrow(directories, allowedPaths);
+        fail('Expected an error to be thrown');
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(McpError);
+        expect(error.code).toBe(ErrorCode.InvalidRequest);
+        expect(error.message).toContain(invalidDir1);
+        expect(error.message).toContain(invalidDir2);
+        expect(error.message).toContain(allowedPaths[0]);
+        expect(error.message).toContain(allowedPaths[1]);
+      }
+    });
+
+    test('should handle empty directories array', () => {
+      expect(() => {
+        validateDirectoriesAndThrow([], allowedPaths);
+      }).not.toThrow();
+    });
+
+    test('should handle empty allowed paths array', () => {
+      const directories = ['C:\\Users\\test\\docs', 'D:\\Projects\\web'];
+      
+      expect(() => {
+        validateDirectoriesAndThrow(directories, []);
+      }).toThrow(McpError);
+    });
+  });
+});


### PR DESCRIPTION
- Implement directory validator utility to validate working directories
- Add support for GitBash style paths (/c/path) conversion to Windows format
- Create comprehensive test suite for directory validation
- Update tool description to reference new validation functionality