### PR TITLE
Fix grammar in directory error message

### DIFF
--- a/src/utils/directoryValidator.ts
+++ b/src/utils/directoryValidator.ts
@@ -53,7 +53,7 @@ export function validateDirectoriesAndThrow(directories: string[], allowedPaths:
     if (result.invalidDirectories.length === 1) {
       throw new McpError(
         ErrorCode.InvalidRequest,
-        `The following directory is outside allowed paths: ${invalidDirsStr}. Allowed paths are: ${allowedPathsStr}. Commands with restricted directory is not allowed to execute.`
+        `The following directory is outside allowed paths: ${invalidDirsStr}. Allowed paths are: ${allowedPathsStr}. Commands with restricted directory are not allowed to execute.`
       );
     } else {
       throw new McpError(


### PR DESCRIPTION
## Summary
- fix singular error message grammar when a restricted directory is disallowed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fe121c85c832084f9cdf403449219