### PR TITLE
Fix Windows path normalization

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -217,7 +217,7 @@ export function normalizeWindowsPath(inputPath: string): string {
         }
     }
     
-    let finalPath = path.normalize(currentPath);
+    let finalPath = path.win32.normalize(currentPath);
 
     const driveLetterMatchCleanup = finalPath.match(/^([a-z]):(.*)/);
     if (driveLetterMatchCleanup) {

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -136,6 +136,14 @@ describe('Path Normalization', () => {
     expect(normalizeWindowsPath('C:/folder/../other')).toBe('C:\\other');
     expect(normalizeWindowsPath('C:/folder/../')).toBe('C:\\');
   });
+  test('normalizeWindowsPath resolves git bash style relative segments', () => {
+    expect(normalizeWindowsPath('/c/folder/../other')).toBe('C:\\other');
+    expect(normalizeWindowsPath('/c/folder/../')).toBe('C:\\');
+  });
+  test('normalizeWindowsPath handles drive-relative paths', () => {
+    expect(normalizeWindowsPath('C:folder/sub')).toBe('C:\\folder\\sub');
+    expect(normalizeWindowsPath('C:folder/../')).toBe('C:\\');
+  });
 });
 
 describe('Allowed Paths Normalization', () => {

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -132,6 +132,10 @@ describe('Path Normalization', () => {
     expect(normalizeWindowsPath('C:\\\\Users\\\\test')).toBe('C:\\Users\\test');
     expect(normalizeWindowsPath('C:/Users//test')).toBe('C:\\Users\\test');
   });
+  test('normalizeWindowsPath resolves relative segments', () => {
+    expect(normalizeWindowsPath('C:/folder/../other')).toBe('C:\\other');
+    expect(normalizeWindowsPath('C:/folder/../')).toBe('C:\\');
+  });
 });
 
 describe('Allowed Paths Normalization', () => {


### PR DESCRIPTION
## Summary
- normalize windows paths using `path.win32.normalize`
- test resolving relative path segments in normalizeWindowsPath

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fe13713d48320a359b32138976b4c