### PR TITLE
Fix config merge

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -94,14 +94,24 @@ export function loadConfig(configPath?: string): ServerConfig {
 function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<ServerConfig>): ServerConfig {
   const merged: ServerConfig = {
     security: {
-      // If user provided security config, use it entirely, otherwise use default
-      ...(userConfig.security || defaultConfig.security)
+      // Start with defaults then override with any user supplied options
+      ...defaultConfig.security,
+      ...(userConfig.security || {})
     },
     shells: {
-      // Same for each shell - if user provided config, use it entirely
-      powershell: userConfig.shells?.powershell || defaultConfig.shells.powershell,
-      cmd: userConfig.shells?.cmd || defaultConfig.shells.cmd,
-      gitbash: userConfig.shells?.gitbash || defaultConfig.shells.gitbash
+      // Merge each shell config individually so unspecified options fall back to defaults
+      powershell: {
+        ...defaultConfig.shells.powershell,
+        ...(userConfig.shells?.powershell || {})
+      },
+      cmd: {
+        ...defaultConfig.shells.cmd,
+        ...(userConfig.shells?.cmd || {})
+      },
+      gitbash: {
+        ...defaultConfig.shells.gitbash,
+        ...(userConfig.shells?.gitbash || {})
+      }
     }
   };
 

--- a/tests/configNormalization.test.ts
+++ b/tests/configNormalization.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { randomBytes } from 'crypto';
-import { loadConfig } from '../src/utils/config.js';
+import { loadConfig, DEFAULT_CONFIG } from '../src/utils/config.js';
 
 describe('Validate allowedPaths normalization from config', () => {
   let tempDir: string;
@@ -35,5 +35,14 @@ describe('Validate allowedPaths normalization from config', () => {
       path.normalize('c:\\another\\folder'),
       path.normalize('c:\\mnt\\d\\incorrect\\path')
     ]);
+  });
+  
+  test('loadConfig fills missing security settings with defaults', () => {
+    const cfg = loadConfig(CONFIG_PATH);
+    expect(cfg.security.maxCommandLength).toBe(DEFAULT_CONFIG.security.maxCommandLength);
+    expect(cfg.security.blockedCommands).toEqual(DEFAULT_CONFIG.security.blockedCommands);
+    expect(cfg.security.blockedArguments).toEqual(DEFAULT_CONFIG.security.blockedArguments);
+    expect(cfg.security.commandTimeout).toBe(DEFAULT_CONFIG.security.commandTimeout);
+    expect(cfg.security.enableInjectionProtection).toBe(DEFAULT_CONFIG.security.enableInjectionProtection);
   });
 });


### PR DESCRIPTION
## Summary
- ensure `loadConfig` fills in missing settings by deep merging defaults
- test that partial configs retain default security settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fe1214b3c8320a521a45f0505086e