### PR TITLE
Fix extraneous quote in Git Bash example

### DIFF
--- a/src/utils/toolDescription.ts
+++ b/src/utils/toolDescription.ts
@@ -60,7 +60,8 @@ export function buildToolDescription(allowedShells: string[]): string[] {
       "  \"command\": \"ls -la\",",
       "  \"workingDir\": \"/c/Users/username\"",
       "}",
-      "```"
+      "```",
+      ""
     );
   }
 


### PR DESCRIPTION
## Summary
- correct Git Bash example formatting in tool description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fe14845988320bcb9c75ebbd34ceb