### PR TITLE
Revert formatting changes and keep new test

### DIFF
--- a/tests/directoryValidator.test.ts
+++ b/tests/directoryValidator.test.ts
@@ -119,6 +119,18 @@ describe('Directory Validator', () => {
       }
     });
 
+    test('should use singular wording for a single invalid directory', () => {
+      const invalidDir = 'C:\\Windows\\System32';
+
+      try {
+        validateDirectoriesAndThrow([invalidDir], allowedPaths);
+        fail('Expected an error to be thrown');
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(McpError);
+        expect(error.message).toContain('directory is outside');
+      }
+    });
+
     test('should handle empty directories array', () => {
       expect(() => {
         validateDirectoriesAndThrow([], allowedPaths);


### PR DESCRIPTION
## Summary
- revert README and source updates from previous commit
- keep test for singular directory error message

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fe0f6e3008320bcfb06a261c7e69f