### PR TITLE
Remove unused escapeRegex helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,15 +140,6 @@ class CLIServer {
   }
 
   /**
-   * Escapes special characters in a string for use in a regular expression
-   * @param text The string to escape
-   * @returns The escaped string
-   */
-  private escapeRegex(text: string): string {
-    return text.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-  }
-  
-  /**
    * Creates a structured copy of the configuration for external use
    * @returns A serializable version of the configuration
    */


### PR DESCRIPTION
## Summary
- delete unused `escapeRegex` helper

## Testing
- `npx tsc --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b3c588988320b95cf8c2b1ee10aa