### PR TITLE
Add WSL shell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![NPM Version](https://img.shields.io/npm/v/@simonb97/server-win-cli.svg?style=flat)](https://www.npmjs.com/package/@simonb97/server-win-cli?activeTab=versions)
 [![smithery badge](https://smithery.ai/badge/@simonb97/server-win-cli)](https://smithery.ai/server/@simonb97/server-win-cli)
 
-[MCP server](https://modelcontextprotocol.io/introduction) for secure command-line interactions on Windows systems, enabling controlled access to PowerShell, CMD, Git Bash shells.
+[MCP server](https://modelcontextprotocol.io/introduction) for secure command-line interactions on Windows systems, enabling controlled access to PowerShell, CMD, Git Bash and WSL shells.
 It allows MCP clients (like [Claude Desktop](https://claude.ai/download)) to perform operations on your system, similar to [Open Interpreter](https://github.com/OpenInterpreter/open-interpreter).
 
 >[!IMPORTANT]
@@ -35,7 +35,7 @@ It allows MCP clients (like [Claude Desktop](https://claude.ai/download)) to per
 
 ## Features
 
-- **Multi-Shell Support**: Execute commands in PowerShell, Command Prompt (CMD), and Git Bash
+- **Multi-Shell Support**: Execute commands in PowerShell, Command Prompt (CMD), Git Bash, or WSL
 - **Resource Exposure**: View current directory and configuration as MCP resources
 - **Security Controls**:
   - Command blocking (full paths, case variations)
@@ -173,6 +173,12 @@ If no configuration file is found, the server will use a default (restricted) co
       "command": "C:\\Program Files\\Git\\bin\\bash.exe",
       "args": ["-c"],
       "blockedOperators": ["&", "|", ";", "`"]
+    },
+    "wsl": {
+      "enabled": true,
+      "command": "wsl.exe",
+      "args": [],
+      "blockedOperators": ["&", "|", ";", "`"]
     }
   }
 }
@@ -264,6 +270,12 @@ The configuration file is divided into two main sections: `security` and `shells
       "command": "C:\\Program Files\\Git\\bin\\bash.exe",
       "args": ["-c"],
       "blockedOperators": ["&", "|", ";", "`"]  // Block all command chaining
+    },
+    "wsl": {
+      "enabled": true,
+      "command": "wsl.exe",
+      "args": [],
+      "blockedOperators": ["&", "|", ";", "`"]  // Block all command chaining
     }
   }
 }
@@ -292,7 +304,7 @@ You can execute a series of commands in one request by joining them with `&&`. T
 
   - Execute a command in the specified shell
   - Inputs:
-    - `shell` (string): Shell to use ("powershell", "cmd", or "gitbash")
+    - `shell` (string): Shell to use ("powershell", "cmd", "gitbash", or "wsl")
     - `command` (string): Command to execute
     - `workingDir` (optional string): Working directory
   - Returns command output as text, or error message if execution fails

--- a/README.md
+++ b/README.md
@@ -178,11 +178,14 @@ If no configuration file is found, the server will use a default (restricted) co
       "enabled": true,
       "command": "wsl.exe",
       "args": [],
+      "instanceName": "",
       "blockedOperators": ["&", "|", ";", "`"]
     }
   }
 }
 ```
+
+`instanceName` defines which WSL distribution is used; an empty string means the default instance will run commands.
 
 ### Configuration Settings
 
@@ -275,11 +278,14 @@ The configuration file is divided into two main sections: `security` and `shells
       "enabled": true,
       "command": "wsl.exe",
       "args": [],
+      "instanceName": "", // Optional WSL distribution name
       "blockedOperators": ["&", "|", ";", "`"]  // Block all command chaining
     }
   }
 }
 ```
+
+- `instanceName` allows specifying which WSL distribution to use. Leave it empty to use the default instance.
 
 
 #### Chained Commands
@@ -304,7 +310,7 @@ You can execute a series of commands in one request by joining them with `&&`. T
 
   - Execute a command in the specified shell
   - Inputs:
-    - `shell` (string): Shell to use ("powershell", "cmd", "gitbash", or "wsl")
+    - `shell` (string): Shell to use ("powershell", "cmd", "gitbash", or "wsl" - uses configured `instanceName` if provided)
     - `command` (string): Command to execute
     - `workingDir` (optional string): Working directory
   - Returns command output as text, or error message if execution fails

--- a/config.sample.json
+++ b/config.sample.json
@@ -44,6 +44,7 @@
       "enabled": true,
       "command": "wsl.exe",
       "args": [],
+      "instanceName": "",
       "blockedOperators": ["&", "|", ";", "`"]
     }
   }

--- a/config.sample.json
+++ b/config.sample.json
@@ -39,6 +39,12 @@
       "command": "C:\\Program Files\\Git\\bin\\bash.exe",
       "args": ["-c"],
       "blockedOperators": ["&", "|", ";", "`"]
+    },
+    "wsl": {
+      "enabled": true,
+      "command": "wsl.exe",
+      "args": [],
+      "blockedOperators": ["&", "|", ";", "`"]
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,9 +287,13 @@ class CLIServer {
               let shellProcess: ReturnType<typeof spawn>;
               
               try {
+                const spawnArgs = [...shellConfig.args];
+                if (shellKey === 'wsl' && shellConfig.instanceName) {
+                  spawnArgs.push('-d', shellConfig.instanceName);
+                }
                 shellProcess = spawn(
                   shellConfig.command,
-                  [...shellConfig.args, args.command],
+                  [...spawnArgs, args.command],
                   { cwd: workingDir, stdio: ['pipe', 'pipe', 'pipe'] }
                 );
               } catch (err) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -22,5 +22,6 @@ export interface ServerConfig {
     powershell: ShellConfig;
     cmd: ShellConfig;
     gitbash: ShellConfig;
+    wsl: ShellConfig;
   };
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -14,6 +14,8 @@ export interface ShellConfig {
   args: string[];
   validatePath?: (dir: string) => boolean;
   blockedOperators?: string[]; // Added for shell-specific operator restrictions
+  /** Optional WSL instance name (ignored for other shells). Empty string uses the default instance */
+  instanceName?: string;
 }
 
 export interface ServerConfig {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -54,6 +54,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
       enabled: true,
       command: 'wsl.exe',
       args: [],
+      instanceName: '',
       validatePath: (dir: string) => dir.match(defaultValidatePathRegex) !== null,
       blockedOperators: ['&', '|', ';', '`']
     }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -49,6 +49,13 @@ export const DEFAULT_CONFIG: ServerConfig = {
       args: ['-c'],
       validatePath: (dir: string) => dir.match(defaultValidatePathRegex) !== null,
       blockedOperators: ['&', '|', ';', '`']
+    },
+    wsl: {
+      enabled: true,
+      command: 'wsl.exe',
+      args: [],
+      validatePath: (dir: string) => dir.match(defaultValidatePathRegex) !== null,
+      blockedOperators: ['&', '|', ';', '`']
     }
   },
 };
@@ -112,6 +119,10 @@ function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<ServerCon
       gitbash: {
         ...defaultConfig.shells.gitbash,
         ...(userConfig.shells?.gitbash || {})
+      },
+      wsl: {
+        ...defaultConfig.shells.wsl,
+        ...(userConfig.shells?.wsl || {})
       }
     }
   };

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -21,7 +21,8 @@ export function createSerializableConfig(config: ServerConfig): any {
         enabled: shell.enabled,
         command: shell.command,
         args: [...shell.args],
-        blockedOperators: shell.blockedOperators ? [...shell.blockedOperators] : []
+        blockedOperators: shell.blockedOperators ? [...shell.blockedOperators] : [],
+        ...(shell.instanceName !== undefined ? { instanceName: shell.instanceName } : {})
       };
       return acc;
     }, {} as Record<string, any>)

--- a/src/utils/toolDescription.ts
+++ b/src/utils/toolDescription.ts
@@ -63,5 +63,19 @@ export function buildToolDescription(allowedShells: string[]): string[] {
     );
   }
 
+  if (allowedShells.includes('wsl')) {
+    descriptionLines.push(
+      "Example usage (WSL):",
+      "```json",
+      "{",
+      "  \"shell\": \"wsl\",",
+      "  \"command\": \"ls -la\",",
+      "  \"workingDir\": \"/home/username\"",
+      "}",
+      "```",
+      ""
+    );
+  }
+
   return descriptionLines;
 }

--- a/tests/getConfig.test.ts
+++ b/tests/getConfig.test.ts
@@ -51,6 +51,12 @@ describe('get_config tool', () => {
         command: 'bash.exe',
         args: ['-c'],
         blockedOperators: ['&', '|']
+      },
+      wsl: {
+        enabled: true,
+        command: 'wsl.exe',
+        args: [],
+        blockedOperators: ['&', '|']
       }
     }
   };
@@ -81,11 +87,13 @@ describe('get_config tool', () => {
     
     expect(safeConfig.shells.cmd.enabled).toBe(testConfig.shells.cmd.enabled);
     expect(safeConfig.shells.gitbash.enabled).toBe(testConfig.shells.gitbash.enabled);
+    expect(safeConfig.shells.wsl.enabled).toBe(testConfig.shells.wsl.enabled);
     
     // Verify that function properties are not included in the serializable config
     expect(safeConfig.shells.powershell.validatePath).toBeUndefined();
     expect(safeConfig.shells.cmd.validatePath).toBeUndefined();
     expect(safeConfig.shells.gitbash.validatePath).toBeUndefined();
+    expect(safeConfig.shells.wsl.validatePath).toBeUndefined();
 
   });
 

--- a/tests/getConfig.test.ts
+++ b/tests/getConfig.test.ts
@@ -56,6 +56,7 @@ describe('get_config tool', () => {
         enabled: true,
         command: 'wsl.exe',
         args: [],
+        instanceName: 'Ubuntu',
         blockedOperators: ['&', '|']
       }
     }
@@ -88,6 +89,7 @@ describe('get_config tool', () => {
     expect(safeConfig.shells.cmd.enabled).toBe(testConfig.shells.cmd.enabled);
     expect(safeConfig.shells.gitbash.enabled).toBe(testConfig.shells.gitbash.enabled);
     expect(safeConfig.shells.wsl.enabled).toBe(testConfig.shells.wsl.enabled);
+    expect(safeConfig.shells.wsl.instanceName).toBe(testConfig.shells.wsl.instanceName);
     
     // Verify that function properties are not included in the serializable config
     expect(safeConfig.shells.powershell.validatePath).toBeUndefined();
@@ -121,6 +123,9 @@ describe('get_config tool', () => {
       expect(safeConfig.shells[shellName]).toHaveProperty('command');
       expect(safeConfig.shells[shellName]).toHaveProperty('args');
       expect(safeConfig.shells[shellName]).toHaveProperty('blockedOperators');
+      if (shellName === 'wsl') {
+        expect(safeConfig.shells[shellName]).toHaveProperty('instanceName');
+      }
     });
 
   });

--- a/tests/toolDescription.test.ts
+++ b/tests/toolDescription.test.ts
@@ -5,7 +5,7 @@ describe('Tool Description Generation', () => {
   test('generates correct description with all shells enabled', () => {
     const allowedShells = ['powershell', 'cmd', 'gitbash'];
     const description = buildToolDescription(allowedShells);
-    
+
     // Check header
     expect(description[0]).toBe('Execute a command in the specified shell (powershell, cmd, gitbash)');
     

--- a/tests/toolDescription.test.ts
+++ b/tests/toolDescription.test.ts
@@ -3,25 +3,28 @@ import { buildToolDescription } from '../src/utils/toolDescription.js';
 
 describe('Tool Description Generation', () => {
   test('generates correct description with all shells enabled', () => {
-    const allowedShells = ['powershell', 'cmd', 'gitbash'];
+    const allowedShells = ['powershell', 'cmd', 'gitbash', 'wsl'];
     const description = buildToolDescription(allowedShells);
 
     // Check header
-    expect(description[0]).toBe('Execute a command in the specified shell (powershell, cmd, gitbash)');
+    expect(description[0]).toBe('Execute a command in the specified shell (powershell, cmd, gitbash, wsl)');
     
     // Check that all examples are included
     expect(description).toContain('Example usage (PowerShell):');
     expect(description).toContain('Example usage (CMD):');
     expect(description).toContain('Example usage (Git Bash):');
+    expect(description).toContain('Example usage (WSL):');
     
     // Check specific content for each shell example
     const powershellLine = description.find(line => line.includes('"shell": "powershell"'));
     const cmdLine = description.find(line => line.includes('"shell": "cmd"'));
     const gitbashLine = description.find(line => line.includes('"shell": "gitbash"'));
+    const wslLine = description.find(line => line.includes('"shell": "wsl"'));
     
     expect(powershellLine).toBeDefined();
     expect(cmdLine).toBeDefined();
     expect(gitbashLine).toBeDefined();
+    expect(wslLine).toBeDefined();
   });
 
   test('generates correct description with only cmd enabled', () => {

--- a/tests/wsl.sh
+++ b/tests/wsl.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Simple emulator for wsl.exe used in unit tests
+# Executes provided command string using bash
+
+bash -c "$*"

--- a/tests/wsl.sh
+++ b/tests/wsl.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 # Simple emulator for wsl.exe used in unit tests
-# Executes provided command string using bash
+# Supports optional "-d <instance>" argument then executes remaining command with bash
+
+if [ "$1" = "-d" ]; then
+  shift 2
+fi
 
 bash -c "$*"

--- a/tests/wslEmulator.test.ts
+++ b/tests/wslEmulator.test.ts
@@ -1,0 +1,16 @@
+import { describe, test, expect } from '@jest/globals';
+import { spawnSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const wslPath = path.join(__dirname, 'wsl.sh');
+
+describe('wsl emulator', () => {
+  test('executes commands using bash', () => {
+    const result = spawnSync(wslPath, ['echo hello'], { encoding: 'utf8' });
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('hello');
+  });
+});

--- a/tests/wslEmulator.test.ts
+++ b/tests/wslEmulator.test.ts
@@ -13,4 +13,10 @@ describe('wsl emulator', () => {
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe('hello');
   });
+
+  test('supports distribution flag', () => {
+    const result = spawnSync(wslPath, ['-d', 'Ubuntu', 'echo world'], { encoding: 'utf8' });
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('world');
+  });
 });


### PR DESCRIPTION
## Summary
- add WSL shell to config types and defaults
- include WSL shell in sample config
- update docs mentioning WSL
- add tests for WSL config and a WSL emulator script
- adjust tool description tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684419b6b8b08320b5627d41fd037537