### PR TITLE
Add integration tests

### DIFF
--- a/tests/helpers/TestCLIServer.ts
+++ b/tests/helpers/TestCLIServer.ts
@@ -1,0 +1,60 @@
+import path from 'path';
+import { CLIServer } from '../../src/index.js';
+import { DEFAULT_CONFIG } from '../../src/utils/config.js';
+import type { ServerConfig } from '../../src/types/config.js';
+
+export class TestCLIServer {
+  private server: CLIServer;
+
+  constructor(overrides: Partial<ServerConfig> = {}) {
+    const baseConfig: ServerConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+
+    // Configure wsl shell to use the local emulator script
+    const wslEmulatorPath = path.resolve(process.cwd(), 'scripts/wsl.sh');
+    baseConfig.shells.wsl = {
+      enabled: true,
+      command: wslEmulatorPath,
+      args: ['-e'],
+      validatePath: (dir: string) => /^(\/mnt\/[a-zA-Z]\/|\/)/.test(dir),
+      blockedOperators: ['&', '|', ';', '`']
+    };
+
+    // Disable other shells by default for cross platform reliability
+    baseConfig.shells.powershell.enabled = false;
+    baseConfig.shells.cmd.enabled = false;
+    baseConfig.shells.gitbash.enabled = false;
+
+    // Allow -e argument for the emulator
+    baseConfig.security.blockedArguments = baseConfig.security.blockedArguments.filter(a => a !== '-e');
+
+    // Merge overrides
+    const config: ServerConfig = {
+      ...baseConfig,
+      security: { ...baseConfig.security, ...(overrides.security || {}) },
+      shells: { ...baseConfig.shells, ...(overrides.shells || {}) }
+    } as ServerConfig;
+
+    this.server = new CLIServer(config);
+  }
+
+  async executeCommand(options: { shell: keyof ServerConfig['shells']; command: string; workingDir?: string; }) {
+    const result = await this.server._executeTool({
+      name: 'execute_command',
+      arguments: {
+        shell: options.shell as string,
+        command: options.command,
+        workingDir: options.workingDir
+      }
+    });
+
+    const output = result.content[0]?.text ?? '';
+    const exitCode = (result.metadata as any)?.exitCode ?? -1;
+    const workingDirectory = (result.metadata as any)?.workingDirectory;
+
+    return { ...result, output, exitCode, workingDirectory };
+  }
+
+  async callTool(name: string, args: Record<string, any>) {
+    return this.server._executeTool({ name, arguments: args });
+  }
+}

--- a/tests/integration/endToEnd.test.ts
+++ b/tests/integration/endToEnd.test.ts
@@ -1,0 +1,17 @@
+import { describe, test, expect } from '@jest/globals';
+import { TestCLIServer } from '../helpers/TestCLIServer.js';
+
+describe('End-to-End Scenarios', () => {
+  test('should execute shell command with proper isolation', async () => {
+    const server = new TestCLIServer({ security: { restrictWorkingDirectory: false } });
+    const result = await server.executeCommand({
+      shell: 'wsl',
+      command: 'echo integration-test',
+      workingDir: '/tmp'
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('integration-test');
+    expect(result.workingDirectory).toBe('/tmp');
+  });
+});

--- a/tests/integration/mcpProtocol.test.ts
+++ b/tests/integration/mcpProtocol.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from '@jest/globals';
+import { TestCLIServer } from '../helpers/TestCLIServer.js';
+
+const server = new TestCLIServer({
+  security: { restrictWorkingDirectory: true, allowedPaths: [process.cwd()] }
+});
+
+describe('MCP Protocol Interactions', () => {
+  test('should return configuration via get_config tool', async () => {
+    const result = await server.callTool('get_config', {});
+    const text = result.content[0]?.text ?? '';
+    const cfg = JSON.parse(text);
+    expect(cfg).toHaveProperty('security');
+    expect(cfg).toHaveProperty('shells');
+  });
+
+  test('should validate directories correctly', async () => {
+    const res = await server.callTool('validate_directories', { directories: [process.cwd()] });
+    expect(res.isError).toBe(false);
+    expect(res.content[0].text).toContain('All specified directories');
+  });
+});

--- a/tests/integration/shellExecution.test.ts
+++ b/tests/integration/shellExecution.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from '@jest/globals';
+import { TestCLIServer } from '../helpers/TestCLIServer.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+
+describe('Shell Execution Security', () => {
+  test('should reject commands with blocked operators', async () => {
+    const server = new TestCLIServer();
+    await expect(
+      server.executeCommand({ shell: 'wsl', command: 'echo hi ; ls' })
+    ).rejects.toBeInstanceOf(McpError);
+  });
+
+  test('should enforce working directory restrictions', async () => {
+    const server = new TestCLIServer({
+      security: { restrictWorkingDirectory: true, allowedPaths: ['/allowed'] }
+    });
+
+    await expect(
+      server.executeCommand({ shell: 'wsl', command: 'pwd', workingDir: '/tmp' })
+    ).rejects.toBeInstanceOf(McpError);
+  });
+
+  test('should execute when working directory allowed', async () => {
+    const server = new TestCLIServer({
+      security: { restrictWorkingDirectory: true, allowedPaths: ['/tmp'] }
+    });
+
+    const result = await server.executeCommand({ shell: 'wsl', command: 'pwd', workingDir: '/tmp' });
+    expect(result.exitCode).toBe(0);
+    expect(result.workingDirectory).toBe('/tmp');
+  });
+});


### PR DESCRIPTION
## Summary
- add TestCLIServer helper
- add integration test suite with end-to-end, protocol and security tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68448b9d5ddc8320ac30046be1bd0e71