### PR TITLE
Add test fixtures for standard configs and data

### DIFF
--- a/tests/commandChain.test.ts
+++ b/tests/commandChain.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_CONFIG } from '../src/utils/config.js';
 import { mockWindowsPaths } from './helpers/pathHelpers.js';
 import { normalizeWindowsPath } from '../src/utils/validation.js';
 import { buildTestConfig } from './helpers/testUtils.js';
+import { testPaths } from './fixtures/testData.js';
 
 mockWindowsPaths();
 jest.mock('@modelcontextprotocol/sdk/server/index.js', () => {
@@ -28,7 +29,7 @@ let tempDir: string;
 let config: any;
 
 beforeAll(() => {
-  tempDir = '/c/win-cli-test';
+  tempDir = testPaths.tempDir;
   config = buildTestConfig({
     security: {
       ...DEFAULT_CONFIG.security, // Start with all defaults

--- a/tests/commandSettings.test.ts
+++ b/tests/commandSettings.test.ts
@@ -4,6 +4,7 @@ import { MockCLIServer } from './helpers/MockCLIServer.js';
 import { DEFAULT_CONFIG } from '../src/utils/config.js';
 import { mockWindowsPaths } from './helpers/pathHelpers.js';
 import { buildTestConfig } from './helpers/testUtils.js';
+import { testPaths } from './fixtures/testData.js';
 
 mockWindowsPaths();
 
@@ -28,7 +29,7 @@ let tempDir: string;
 let baseConfig: any;
 
 beforeAll(() => {
-  tempDir = '/c/win-cli-test';
+  tempDir = testPaths.tempDir;
   baseConfig = buildTestConfig({
     security: {
       allowedPaths: [tempDir],

--- a/tests/errorHandling.test.ts
+++ b/tests/errorHandling.test.ts
@@ -1,13 +1,14 @@
 import { describe, test, expect, jest } from '@jest/globals';
 import { CLIServer } from '../src/index.js';
 import { DEFAULT_CONFIG, loadConfig } from '../src/utils/config.js';
+import { baseConfig } from './fixtures/configs.js';
 import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import fs from 'fs';
 import path from 'path';
 
 describe('Error Handling', () => {
   test('should handle malformed JSON-RPC requests', async () => {
-    const server = new CLIServer(DEFAULT_CONFIG);
+    const server = new CLIServer(baseConfig);
     await expect(
       server._executeTool({ name: 'execute_command', arguments: { shell: 'cmd' } })
     ).rejects.toEqual(

--- a/tests/fixtures/configs.ts
+++ b/tests/fixtures/configs.ts
@@ -1,0 +1,40 @@
+import { ServerConfig } from '../../src/types/config.js';
+import { buildTestConfig } from '../helpers/testUtils.js';
+
+/**
+ * Collection of standard ServerConfig objects for test suites.
+ */
+
+/** Base configuration cloned from DEFAULT_CONFIG for general test usage. */
+export const baseConfig: ServerConfig = buildTestConfig();
+
+/** Secure configuration used for strict security scenarios. */
+export const secureConfig: ServerConfig = buildTestConfig({
+  security: {
+    maxCommandLength: 1000,
+    blockedCommands: ['rm', 'del', 'format'],
+    blockedArguments: ['--system', '-rf'],
+    allowedPaths: ['C\\safe\\path'],
+    restrictWorkingDirectory: true,
+    commandTimeout: 30,
+    enableInjectionProtection: true,
+  },
+  shells: {
+    powershell: {
+      enabled: true,
+      command: 'powershell.exe',
+      args: ['-NoProfile', '-Command'],
+      blockedOperators: ['&', ';', '`'],
+    },
+  },
+});
+
+/** Permissive configuration with relaxed security for convenience tests. */
+export const permissiveConfig: ServerConfig = buildTestConfig({
+  security: {
+    blockedCommands: [],
+    blockedArguments: [],
+    restrictWorkingDirectory: false,
+    enableInjectionProtection: false,
+  },
+});

--- a/tests/fixtures/testData.ts
+++ b/tests/fixtures/testData.ts
@@ -1,0 +1,25 @@
+/**
+ * Common reusable strings and helper builders for unit tests.
+ */
+
+export const testPaths = {
+  tempDir: '/c/win-cli-test',
+  windowsDir: 'C\\Windows',
+  safeDir: 'C\\safe\\path',
+};
+
+export const commands = {
+  echo: 'echo hi',
+  blocked: 'rm file.txt',
+  injection: 'echo hi & echo there',
+};
+
+/**
+ * Build a chained command for testing command parsing and validation.
+ *
+ * @param dir - Directory to change into before running the command
+ * @param cmd - Command to execute after the directory change
+ */
+export function chainCommand(dir: string, cmd: string): string {
+  return `cd ${dir} && ${cmd}`;
+}


### PR DESCRIPTION
## Summary
- add new `tests/fixtures` with reusable configs and test data
- update command chain, command settings and error handling tests to use fixtures
- document and type fixtures

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844cbc2efbc832093340e55e9b15d27