### PR TITLE
feat: Implement explicit CWD initialization

### DIFF
--- a/tests/cwdInitialization.test.ts
+++ b/tests/cwdInitialization.test.ts
@@ -1,0 +1,392 @@
+import { CLIServer } from '../src/index';
+import { normalizeWindowsPath } from '../src/utils/validation';
+import type { ServerConfig } from '../src/types/config';
+
+// Mock process.cwd, process.chdir, and console.error
+const mockProcessCwd = jest.spyOn(process, 'cwd');
+const mockProcessChdir = jest.spyOn(process, 'chdir').mockImplementation(() => true); // Prevent actual chdir
+const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {}); // Suppress console logs
+
+describe('CLIServer CWD Initialization and Interaction', () => {
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd(); // Store original CWD to restore if needed, though mocks should prevent changes
+    mockProcessCwd.mockClear();
+    mockProcessChdir.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  afterEach(() => {
+    // Restore original CWD if mock wasn't effective (should not be necessary with proper mocking)
+    // process.chdir(originalCwd);
+  });
+
+  describe('Constructor / Startup Logic', () => {
+    it('Case 1: restrictWorkingDirectory: true, launchDir NOT in allowedPaths', () => {
+      mockProcessCwd.mockReturnValue('C:\\forbidden');
+      const config: ServerConfig = {
+        security: {
+          restrictWorkingDirectory: true,
+          allowedPaths: ['C:\\allowed1', 'D:\\another'],
+          blockedCommands: [],
+          blockedArguments: [],
+          enableInjectionProtection: true,
+          maxCommandLength: 1000,
+          commandTimeout: 10,
+        },
+        shells: { cmd: { enabled: true, command: 'cmd.exe', args: ['/c'] } },
+      };
+      const server = new CLIServer(config);
+      // @ts-expect-error accessing private member for test
+      expect(server.serverActiveCwd).toBeUndefined();
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining("INFO: Server started in directory: C:\\forbidden."));
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining("INFO: 'restrictWorkingDirectory' is enabled, and this directory is not in the configured 'allowedPaths'."));
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining("INFO: The server's active working directory is currently NOT SET."));
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining(`INFO: Configured allowed paths are: ${normalizeWindowsPath('C:\\allowed1')}, ${normalizeWindowsPath('D:\\another')}.`));
+    });
+
+    it('Case 2: restrictWorkingDirectory: true, launchDir IS in allowedPaths', () => {
+      const launchDir = 'C:\\allowed1\\subdir';
+      mockProcessCwd.mockReturnValue(launchDir);
+      const config: ServerConfig = {
+        security: {
+          restrictWorkingDirectory: true,
+          allowedPaths: ['C:\\allowed1', 'D:\\another'],
+          blockedCommands: [],
+          blockedArguments: [],
+          enableInjectionProtection: true,
+          maxCommandLength: 1000,
+          commandTimeout: 10,
+        },
+        shells: { cmd: { enabled: true, command: 'cmd.exe', args: ['/c'] } },
+      };
+      const server = new CLIServer(config);
+      const expectedNormalizedPath = normalizeWindowsPath(launchDir);
+      // @ts-expect-error accessing private member for test
+      expect(server.serverActiveCwd).toBe(expectedNormalizedPath);
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining(`INFO: Server's active working directory initialized to: ${expectedNormalizedPath}.`));
+    });
+
+    it('Case 3: restrictWorkingDirectory: false', () => {
+      const launchDir = 'C:\\anywhere';
+      mockProcessCwd.mockReturnValue(launchDir);
+      const config: ServerConfig = {
+        security: {
+          restrictWorkingDirectory: false,
+          allowedPaths: ['C:\\allowed1'], // Should be ignored
+          blockedCommands: [],
+          blockedArguments: [],
+          enableInjectionProtection: true,
+          maxCommandLength: 1000,
+          commandTimeout: 10,
+        },
+        shells: { cmd: { enabled: true, command: 'cmd.exe', args: ['/c'] } },
+      };
+      const server = new CLIServer(config);
+      const expectedNormalizedPath = normalizeWindowsPath(launchDir);
+      // @ts-expect-error accessing private member for test
+      expect(server.serverActiveCwd).toBe(expectedNormalizedPath);
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining(`INFO: Server's active working directory initialized to: ${expectedNormalizedPath}.`));
+    });
+
+    it('Case 4: restrictWorkingDirectory: true, allowedPaths is empty', () => {
+      mockProcessCwd.mockReturnValue('C:\\somepath');
+      const config: ServerConfig = {
+        security: {
+          restrictWorkingDirectory: true,
+          allowedPaths: [], // Empty
+          blockedCommands: [],
+          blockedArguments: [],
+          enableInjectionProtection: true,
+          maxCommandLength: 1000,
+          commandTimeout: 10,
+        },
+        shells: { cmd: { enabled: true, command: 'cmd.exe', args: ['/c'] } },
+      };
+      const server = new CLIServer(config);
+      // @ts-expect-error accessing private member for test
+      expect(server.serverActiveCwd).toBeUndefined(); // No path can be allowed
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining("INFO: Server started in directory: C:\\somepath."));
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining("INFO: 'restrictWorkingDirectory' is enabled, and this directory is not in the configured 'allowedPaths'."));
+      // Note: The message "Configured allowed paths are: ." might appear if allowedPaths is empty. This is acceptable.
+    });
+
+    it('Case 5: restrictWorkingDirectory: true, allowedPaths is undefined', () => {
+      mockProcessCwd.mockReturnValue('C:\\somepath');
+      const config: ServerConfig = {
+        security: {
+          restrictWorkingDirectory: true,
+          // allowedPaths is undefined
+          blockedCommands: [],
+          blockedArguments: [],
+          enableInjectionProtection: true,
+          maxCommandLength: 1000,
+          commandTimeout: 10,
+        },
+        shells: { cmd: { enabled: true, command: 'cmd.exe', args: ['/c'] } },
+      };
+      const server = new CLIServer(config);
+      // @ts-expect-error accessing private member for test
+      expect(server.serverActiveCwd).toBeUndefined(); // No path can be allowed
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining("INFO: Server started in directory: C:\\somepath."));
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining("INFO: 'restrictWorkingDirectory' is enabled, and this directory is not in the configured 'allowedPaths'."));
+    });
+  });
+
+  describe('Full Interaction Flow Test', () => {
+    it('should correctly handle CWD operations throughout server lifecycle', async () => {
+      mockProcessCwd.mockReturnValue('C:\\forbidden'); // Initial CWD is not allowed
+      const allowedDir = 'C:\\allowed';
+      const normalizedAllowedDir = normalizeWindowsPath(allowedDir);
+      const config: ServerConfig = {
+        security: {
+          restrictWorkingDirectory: true,
+          allowedPaths: [allowedDir],
+          blockedCommands: [],
+          blockedArguments: [],
+          enableInjectionProtection: true,
+          maxCommandLength: 1000,
+          commandTimeout: 10,
+        },
+        shells: { cmd: { enabled: true, command: 'cmd.exe', args: ['/c'], // Mock actual command execution if needed
+          },
+        },
+      };
+
+      const server = new CLIServer(config);
+
+      // 1. Assert serverActiveCwd is undefined initially
+      // @ts-expect-error accessing private member for test
+      expect(server.serverActiveCwd).toBeUndefined();
+
+      // 2. Call get_current_directory
+      let result = await server._executeTool({ name: 'get_current_directory', arguments: {} });
+      expect(result.content?.[0].text).toBe("The server's active working directory is not currently set. Use 'set_current_directory' to set it.");
+
+      // 3. Call execute_command without workingDir - should fail
+      result = await server._executeTool({
+        name: 'execute_command',
+        arguments: { shell: 'cmd', command: 'echo test' },
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0].text).toContain("Error: Server's active working directory is not set.");
+
+      // 4. Call set_current_directory with an allowed path
+      mockProcessChdir.mockClear(); // Clear before testing chdir call
+      result = await server._executeTool({
+        name: 'set_current_directory',
+        arguments: { path: allowedDir },
+      });
+      expect(result.isError).toBe(false);
+      expect(result.content?.[0].text).toBe(`Server's active working directory changed to: ${normalizedAllowedDir}`);
+      // @ts-expect-error accessing private member for test
+      expect(server.serverActiveCwd).toBe(normalizedAllowedDir);
+      expect(mockProcessChdir).toHaveBeenCalledWith(normalizedAllowedDir);
+
+      // 5. Call get_current_directory again
+      result = await server._executeTool({ name: 'get_current_directory', arguments: {} });
+      expect(result.content?.[0].text).toBe(normalizedAllowedDir);
+
+      // 6. Call execute_command without workingDir - should succeed now
+      // Mocking spawn for this part to avoid actual execution and focus on CWD
+      const mockSpawn = jest.fn().mockReturnValue({
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        on: jest.fn((event, cb) => { if (event === 'close') cb(0); }), // Simulate successful close
+        kill: jest.fn(),
+      });
+      const childProcess = await import('child_process');
+      const originalSpawn = childProcess.spawn;
+      (childProcess as any).spawn = mockSpawn;
+
+      result = await server._executeTool({
+        name: 'execute_command',
+        arguments: { shell: 'cmd', command: 'echo test_successful' },
+      });
+      expect(result.isError).toBe(false);
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'cmd.exe',
+        ['/c', 'echo test_successful'],
+        expect.objectContaining({ cwd: normalizedAllowedDir }) // Crucial check
+      );
+
+      // Restore spawn
+      (childProcess as any).spawn = originalSpawn;
+
+      // 7. Call set_current_directory with a forbidden path
+      const forbiddenDir = 'C:\\other_forbidden';
+      const normalizedForbiddenDir = normalizeWindowsPath(forbiddenDir);
+      result = await server._executeTool({
+        name: 'set_current_directory',
+        arguments: { path: forbiddenDir },
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0].text).toContain(`Failed to set current directory: Working directory (${normalizedForbiddenDir}) outside allowed paths`);
+      // @ts-expect-error accessing private member for test
+      expect(server.serverActiveCwd).toBe(normalizedAllowedDir); // Should not have changed
+
+      // 8. Call execute_command with an explicit, allowed workingDir (different from serverActiveCwd)
+      const explicitAllowedSubDir = normalizeWindowsPath('C:\\allowed\\explicit_subdir');
+      // Ensure the explicit subdir is indeed considered allowed by the main path 'C:\\allowed'
+      // Our isPathAllowed and validateWorkingDirectory should handle this if 'C:\\allowed' is a parent.
+
+      mockProcessCwd.mockReturnValue(normalizedAllowedDir); // Ensure process.cwd() for the test is the serverActiveCwd
+
+      const childProcessAgain = await import('child_process');
+      const originalSpawnAgain = childProcessAgain.spawn;
+      const mockSpawnAgain = jest.fn().mockReturnValue({
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        on: jest.fn((event, cb) => { if (event === 'close') cb(0); }),
+        kill: jest.fn(),
+      });
+      (childProcessAgain as any).spawn = mockSpawnAgain;
+
+      result = await server._executeTool({
+        name: 'execute_command',
+        arguments: { shell: 'cmd', command: 'echo test_explicit', workingDir: explicitAllowedSubDir },
+      });
+      expect(result.isError).toBe(false);
+      expect(mockSpawnAgain).toHaveBeenCalledWith(
+        'cmd.exe',
+        ['/c', 'echo test_explicit'],
+        expect.objectContaining({ cwd: explicitAllowedSubDir }) // Check explicit WD is used
+      );
+      (childProcessAgain as any).spawn = originalSpawnAgain; // Restore spawn
+    });
+  });
+
+  describe('execute_command Tool (CWD Handling Focus)', () => {
+    const allowedDir = 'C:\\allowed_exec';
+    const normalizedAllowedDir = normalizeWindowsPath(allowedDir);
+    const anotherAllowedDir = 'C:\\another_allowed_exec';
+    const normalizedAnotherAllowedDir = normalizeWindowsPath(anotherAllowedDir);
+    const forbiddenInitialDir = 'C:\\forbidden_exec_initial';
+
+    let server: CLIServer;
+    let mockSpawn: jest.SpyInstance;
+    let originalSpawn: typeof import('child_process').spawn;
+
+    beforeEach(async () => {
+      mockProcessCwd.mockClear();
+      mockProcessChdir.mockClear();
+      mockConsoleError.mockClear();
+
+      const childProcessModule = await import('child_process');
+      originalSpawn = childProcessModule.spawn;
+      mockSpawn = jest.spyOn(childProcessModule, 'spawn').mockImplementation((): any => {
+        const process = new (require('events').EventEmitter)();
+        process.stdout = new (require('events').EventEmitter)();
+        process.stderr = new (require('events').EventEmitter)();
+        setTimeout(() => process.emit('close', 0), 0); // Simulate success
+        return process;
+      });
+    });
+
+    afterEach(() => {
+      mockSpawn.mockRestore();
+    });
+
+    test('should FAIL if serverActiveCwd is undefined and no workingDir is provided', async () => {
+      mockProcessCwd.mockReturnValue(forbiddenInitialDir); // Ensures serverActiveCwd is undefined
+      const config: ServerConfig = {
+        security: {
+          restrictWorkingDirectory: true,
+          allowedPaths: [normalizedAllowedDir], // Only one allowed path
+          blockedCommands: [], blockedArguments: [], enableInjectionProtection: true, maxCommandLength: 1000, commandTimeout: 10,
+        },
+        shells: { cmd: { enabled: true, command: 'cmd.exe', args: ['/c'] } },
+      };
+      server = new CLIServer(config);
+      // @ts-expect-error
+      expect(server.serverActiveCwd).toBeUndefined(); // Verify precondition
+
+      const result = await server._executeTool({
+        name: 'execute_command',
+        arguments: { shell: 'cmd', command: 'echo test' },
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0].text).toContain("Error: Server's active working directory is not set.");
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    test('should SUCCEED with provided workingDir even if serverActiveCwd is undefined', async () => {
+      mockProcessCwd.mockReturnValue(forbiddenInitialDir); // Ensures serverActiveCwd is undefined
+      const config: ServerConfig = {
+        security: {
+          restrictWorkingDirectory: true,
+          allowedPaths: [normalizedAllowedDir],
+          blockedCommands: [], blockedArguments: [], enableInjectionProtection: true, maxCommandLength: 1000, commandTimeout: 10,
+        },
+        shells: { cmd: { enabled: true, command: 'cmd.exe', args: ['/c'] } },
+      };
+      server = new CLIServer(config);
+      // @ts-expect-error
+      expect(server.serverActiveCwd).toBeUndefined(); // Verify precondition
+
+      const result = await server._executeTool({
+        name: 'execute_command',
+        arguments: { shell: 'cmd', command: 'echo test', workingDir: normalizedAllowedDir },
+      });
+      expect(result.isError).toBe(false);
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'cmd.exe',
+        ['/c', 'echo test'],
+        expect.objectContaining({ cwd: normalizedAllowedDir })
+      );
+    });
+
+    test('should SUCCEED using serverActiveCwd if it is defined and no workingDir is provided', async () => {
+      mockProcessCwd.mockReturnValue(normalizedAllowedDir); // Ensures serverActiveCwd is defined
+      const config: ServerConfig = {
+        security: {
+          restrictWorkingDirectory: true,
+          allowedPaths: [normalizedAllowedDir, normalizedAnotherAllowedDir],
+          blockedCommands: [], blockedArguments: [], enableInjectionProtection: true, maxCommandLength: 1000, commandTimeout: 10,
+        },
+        shells: { cmd: { enabled: true, command: 'cmd.exe', args: ['/c'] } },
+      };
+      server = new CLIServer(config);
+      // @ts-expect-error
+      expect(server.serverActiveCwd).toBe(normalizedAllowedDir); // Verify precondition
+
+      const result = await server._executeTool({
+        name: 'execute_command',
+        arguments: { shell: 'cmd', command: 'echo test' },
+      });
+      expect(result.isError).toBe(false);
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'cmd.exe',
+        ['/c', 'echo test'],
+        expect.objectContaining({ cwd: normalizedAllowedDir })
+      );
+    });
+
+    test('should SUCCEED with provided workingDir, overriding serverActiveCwd', async () => {
+      mockProcessCwd.mockReturnValue(normalizedAllowedDir); // serverActiveCwd will be normalizedAllowedDir
+      const config: ServerConfig = {
+        security: {
+          restrictWorkingDirectory: true,
+          allowedPaths: [normalizedAllowedDir, normalizedAnotherAllowedDir],
+          blockedCommands: [], blockedArguments: [], enableInjectionProtection: true, maxCommandLength: 1000, commandTimeout: 10,
+        },
+        shells: { cmd: { enabled: true, command: 'cmd.exe', args: ['/c'] } },
+      };
+      server = new CLIServer(config);
+      // @ts-expect-error
+      expect(server.serverActiveCwd).toBe(normalizedAllowedDir); // Verify precondition
+
+      const result = await server._executeTool({
+        name: 'execute_command',
+        arguments: { shell: 'cmd', command: 'echo test', workingDir: normalizedAnotherAllowedDir },
+      });
+      expect(result.isError).toBe(false);
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'cmd.exe',
+        ['/c', 'echo test'],
+        expect.objectContaining({ cwd: normalizedAnotherAllowedDir }) // Explicit workingDir used
+      );
+    });
+  });
+});

--- a/tests/getConfig.test.ts
+++ b/tests/getConfig.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, test, jest } from '@jest/globals';
+import { describe, expect, test, jest, beforeEach, afterEach } from '@jest/globals';
 import { ServerConfig } from '../src/types/config.js';
+import { CLIServer } from '../src/index'; // Import CLIServer
+import { normalizeWindowsPath } from '../src/utils/validation'; // Import normalizeWindowsPath
 import { createSerializableConfig } from '../src/utils/configUtils.js';
+
+// Mock process.cwd, process.chdir, and console.error for CWD tests
+// Ensure these mocks are set up before CLIServer is instantiated in tests
+const mockProcessCwd = jest.spyOn(process, 'cwd');
+const mockProcessChdir = jest.spyOn(process, 'chdir').mockImplementation(() => true); // Prevent actual chdir
+const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {}); // Suppress console logs for cleaner test output
 
 // Mock the Server class from MCP SDK
 jest.mock('@modelcontextprotocol/sdk/server/index.js', () => {
@@ -21,10 +29,29 @@ jest.mock('@modelcontextprotocol/sdk/server/stdio.js', () => {
   };
 });
 
-describe('get_config tool', () => {
-  // Sample test config
-  const testConfig: ServerConfig = {
-    security: {
+// Sample base config for CLIServer instantiation in CWD tests
+const baseTestConfig: ServerConfig = {
+  security: {
+    maxCommandLength: 1000,
+    blockedCommands: [],
+    blockedArguments: [],
+    allowedPaths: ['C:\\allowed'], // Default allowed path for tests
+    restrictWorkingDirectory: true,
+    commandTimeout: 30,
+    enableInjectionProtection: true
+  },
+  shells: {
+    cmd: { enabled: true, command: 'cmd.exe', args: ['/c'] }
+  }
+};
+
+
+describe('Configuration and CWD Tools', () => {
+
+  describe('get_config tool', () => {
+    // Sample test config for get_config specific tests
+    const getConfigSpecificTestConfig: ServerConfig = {
+      security: {
       maxCommandLength: 1000,
       blockedCommands: ['rm', 'del'],
       blockedArguments: ['--exec'],
@@ -56,8 +83,8 @@ describe('get_config tool', () => {
   };
 
   test('createSerializableConfig returns structured configuration', () => {
-    // Call the utility function directly with our test config
-    const safeConfig = createSerializableConfig(testConfig);
+    // Call the utility function directly with our test config for get_config
+    const safeConfig = createSerializableConfig(getConfigSpecificTestConfig);
     
     // Verify the structure and content of the safe config
     expect(safeConfig).toBeDefined();
@@ -65,22 +92,22 @@ describe('get_config tool', () => {
     expect(safeConfig.shells).toBeDefined();
     
     // Check security settings
-    expect(safeConfig.security.maxCommandLength).toBe(testConfig.security.maxCommandLength);
-    expect(safeConfig.security.blockedCommands).toEqual(testConfig.security.blockedCommands);
-    expect(safeConfig.security.blockedArguments).toEqual(testConfig.security.blockedArguments);
-    expect(safeConfig.security.allowedPaths).toEqual(testConfig.security.allowedPaths);
-    expect(safeConfig.security.restrictWorkingDirectory).toBe(testConfig.security.restrictWorkingDirectory);
-    expect(safeConfig.security.commandTimeout).toBe(testConfig.security.commandTimeout);
-    expect(safeConfig.security.enableInjectionProtection).toBe(testConfig.security.enableInjectionProtection);
+    expect(safeConfig.security.maxCommandLength).toBe(getConfigSpecificTestConfig.security.maxCommandLength);
+    expect(safeConfig.security.blockedCommands).toEqual(getConfigSpecificTestConfig.security.blockedCommands);
+    expect(safeConfig.security.blockedArguments).toEqual(getConfigSpecificTestConfig.security.blockedArguments);
+    expect(safeConfig.security.allowedPaths).toEqual(getConfigSpecificTestConfig.security.allowedPaths);
+    expect(safeConfig.security.restrictWorkingDirectory).toBe(getConfigSpecificTestConfig.security.restrictWorkingDirectory);
+    expect(safeConfig.security.commandTimeout).toBe(getConfigSpecificTestConfig.security.commandTimeout);
+    expect(safeConfig.security.enableInjectionProtection).toBe(getConfigSpecificTestConfig.security.enableInjectionProtection);
     
     // Check shells configuration
-    expect(safeConfig.shells.powershell.enabled).toBe(testConfig.shells.powershell.enabled);
-    expect(safeConfig.shells.powershell.command).toBe(testConfig.shells.powershell.command);
-    expect(safeConfig.shells.powershell.args).toEqual(testConfig.shells.powershell.args);
-    expect(safeConfig.shells.powershell.blockedOperators).toEqual(testConfig.shells.powershell.blockedOperators);
+    expect(safeConfig.shells.powershell.enabled).toBe(getConfigSpecificTestConfig.shells.powershell.enabled);
+    expect(safeConfig.shells.powershell.command).toBe(getConfigSpecificTestConfig.shells.powershell.command);
+    expect(safeConfig.shells.powershell.args).toEqual(getConfigSpecificTestConfig.shells.powershell.args);
+    expect(safeConfig.shells.powershell.blockedOperators).toEqual(getConfigSpecificTestConfig.shells.powershell.blockedOperators);
     
-    expect(safeConfig.shells.cmd.enabled).toBe(testConfig.shells.cmd.enabled);
-    expect(safeConfig.shells.gitbash.enabled).toBe(testConfig.shells.gitbash.enabled);
+    expect(safeConfig.shells.cmd.enabled).toBe(getConfigSpecificTestConfig.shells.cmd.enabled);
+    expect(safeConfig.shells.gitbash.enabled).toBe(getConfigSpecificTestConfig.shells.gitbash.enabled);
     
     // Verify that function properties are not included in the serializable config
     expect(safeConfig.shells.powershell.validatePath).toBeUndefined();
@@ -90,8 +117,8 @@ describe('get_config tool', () => {
   });
 
   test('createSerializableConfig returns consistent config structure', () => {
-    // Call the utility function directly with our test config
-    const safeConfig = createSerializableConfig(testConfig);
+    // Call the utility function directly with our test config for get_config
+    const safeConfig = createSerializableConfig(getConfigSpecificTestConfig);
     
     // Verify the structure matches what we expect both tools to return
     expect(safeConfig).toHaveProperty('security');
@@ -107,7 +134,7 @@ describe('get_config tool', () => {
     expect(safeConfig.security).toHaveProperty('enableInjectionProtection');
     
     // Verify shells structure
-    Object.keys(testConfig.shells).forEach(shellName => {
+    Object.keys(getConfigSpecificTestConfig.shells).forEach(shellName => {
       expect(safeConfig.shells).toHaveProperty(shellName);
       expect(safeConfig.shells[shellName]).toHaveProperty('enabled');
       expect(safeConfig.shells[shellName]).toHaveProperty('command');
@@ -118,8 +145,8 @@ describe('get_config tool', () => {
   });
   
   test('get_config tool response format', () => {
-    // Call the utility function directly with our test config
-    const safeConfig = createSerializableConfig(testConfig);
+    // Call the utility function directly with our test config for get_config
+    const safeConfig = createSerializableConfig(getConfigSpecificTestConfig);
     
     // Format it as the tool would
     const formattedResponse = {
@@ -149,5 +176,145 @@ describe('get_config tool', () => {
     
     // Verify the content matches what we expect
     expect(parsedConfig).toEqual(safeConfig);
+  });
+});
+
+  describe('get_current_directory tool', () => {
+    beforeEach(() => {
+      mockProcessCwd.mockClear();
+      mockConsoleError.mockClear(); // Clear console mock for each test if needed
+    });
+
+    test('should return serverActiveCwd if set', async () => {
+      const launchDir = 'C:\\allowed\\start';
+      mockProcessCwd.mockReturnValue(launchDir); // serverActiveCwd will be this
+      const server = new CLIServer({ ...baseTestConfig, security: { ...baseTestConfig.security, allowedPaths: ['C:\\allowed'] } });
+
+      const result = await server._executeTool({ name: 'get_current_directory', arguments: {} });
+      expect(result.isError).toBe(false);
+      expect(result.content?.[0].text).toBe(normalizeWindowsPath(launchDir));
+    });
+
+    test('should return "not set" message if serverActiveCwd is undefined', async () => {
+      mockProcessCwd.mockReturnValue('C:\\forbidden'); // This will make serverActiveCwd undefined
+      const server = new CLIServer({
+        ...baseTestConfig,
+        security: { ...baseTestConfig.security, restrictWorkingDirectory: true, allowedPaths: ['C:\\allowedOnly'] }
+      });
+      // @ts-expect-error check private member
+      expect(server.serverActiveCwd).toBeUndefined(); // Pre-condition check
+
+      const result = await server._executeTool({ name: 'get_current_directory', arguments: {} });
+      expect(result.isError).toBe(false); // Informational, not an error
+      expect(result.content?.[0].text).toBe("The server's active working directory is not currently set. Use 'set_current_directory' to set it.");
+    });
+  });
+
+  describe('set_current_directory tool', () => {
+    let server: CLIServer;
+    const allowedDir = 'C:\\allowed';
+    const normalizedAllowedDir = normalizeWindowsPath(allowedDir);
+
+    beforeEach(() => {
+      mockProcessCwd.mockReturnValue('C:\\initial_dir'); // Default for tests where launch dir isn't the focus
+      mockProcessChdir.mockClear();
+      mockConsoleError.mockClear();
+      server = new CLIServer({
+        ...baseTestConfig,
+        security: { ...baseTestConfig.security, restrictWorkingDirectory: true, allowedPaths: [allowedDir] }
+      });
+      // Ensure serverActiveCwd is initially something (or undefined if initial_dir is forbidden)
+      // For these tests, let's assume initial_dir is allowed to simplify focus on set_current_directory
+      mockProcessCwd.mockReturnValue(allowedDir + "\\initial_subdir");
+      server = new CLIServer({
+        ...baseTestConfig,
+        security: { ...baseTestConfig.security, restrictWorkingDirectory: true, allowedPaths: [allowedDir] }
+      });
+       // @ts-expect-error set for test
+      server.serverActiveCwd = normalizeWindowsPath(allowedDir + "\\initial_subdir");
+
+    });
+
+    test('should update serverActiveCwd and call process.chdir for an allowed path', async () => {
+      const newPath = 'C:\\allowed\\newpath';
+      const normalizedNewPath = normalizeWindowsPath(newPath);
+      // @ts-expect-error private member
+      const oldCwd = server.serverActiveCwd;
+
+      const result = await server._executeTool({ name: 'set_current_directory', arguments: { path: newPath } });
+
+      expect(result.isError).toBe(false);
+      expect(result.content?.[0].text).toBe(`Server's active working directory changed to: ${normalizedNewPath}`);
+      // @ts-expect-error private member
+      expect(server.serverActiveCwd).toBe(normalizedNewPath);
+      expect(mockProcessChdir).toHaveBeenCalledWith(normalizedNewPath);
+      expect(result.metadata?.previousActiveDirectory).toBe(oldCwd);
+      expect(result.metadata?.newActiveDirectory).toBe(normalizedNewPath);
+    });
+
+    test('should fail if path is not in allowedPaths when restrictions are on', async () => {
+      const forbiddenPath = 'C:\\forbidden_path';
+      const normalizedForbiddenPath = normalizeWindowsPath(forbiddenPath);
+      // @ts-expect-error private member
+      const originalServerCwd = server.serverActiveCwd;
+      mockProcessChdir.mockClear();
+
+      const result = await server._executeTool({ name: 'set_current_directory', arguments: { path: forbiddenPath } });
+
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0].text).toContain(`Failed to set current directory: Working directory (${normalizedForbiddenPath}) outside allowed paths`);
+      // @ts-expect-error private member
+      expect(server.serverActiveCwd).toBe(originalServerCwd); // Should not change
+      expect(mockProcessChdir).not.toHaveBeenCalled();
+      expect(result.metadata?.requestedDirectory).toBe(forbiddenPath);
+      expect(result.metadata?.activeDirectoryBeforeAttempt).toBe(originalServerCwd);
+    });
+
+    test('should fail if process.chdir throws an error', async () => {
+      const newPath = 'C:\\allowed\\nonexistent_or_error'; // Path is allowed by config
+      const normalizedNewPath = normalizeWindowsPath(newPath);
+      // @ts-expect-error private member
+      const originalServerCwd = server.serverActiveCwd;
+
+      mockProcessChdir.mockImplementationOnce(() => { throw new Error("Simulated chdir error"); });
+
+      const result = await server._executeTool({ name: 'set_current_directory', arguments: { path: newPath } });
+
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0].text).toContain('Failed to set current directory: Simulated chdir error');
+      // @ts-expect-error private member
+      expect(server.serverActiveCwd).toBe(originalServerCwd); // Should not change
+      expect(mockProcessChdir).toHaveBeenCalledWith(normalizedNewPath); // Attempted chdir
+      expect(result.metadata?.requestedDirectory).toBe(newPath);
+      expect(result.metadata?.activeDirectoryBeforeAttempt).toBe(originalServerCwd);
+    });
+
+    test('should allow setting directory if restrictWorkingDirectory is false, even if not in allowedPaths', async () => {
+      const anyPath = 'C:\\any_path_works';
+      const normalizedAnyPath = normalizeWindowsPath(anyPath);
+      mockProcessCwd.mockReturnValue('C:\\initial_allowed'); // ensure initial CWD is fine
+
+      server = new CLIServer({
+        ...baseTestConfig,
+        security: { ...baseTestConfig.security, restrictWorkingDirectory: false, allowedPaths: ['C:\\specific_allowed'] } // restrictions off
+      });
+       // @ts-expect-error set for test
+      server.serverActiveCwd = normalizeWindowsPath('C:\\initial_allowed'); // Set initial active CWD
+
+      mockProcessChdir.mockClear();
+      // @ts-expect-error private member
+      const oldCwd = server.serverActiveCwd;
+
+
+      const result = await server._executeTool({ name: 'set_current_directory', arguments: { path: anyPath } });
+
+      expect(result.isError).toBe(false);
+      expect(result.content?.[0].text).toBe(`Server's active working directory changed to: ${normalizedAnyPath}`);
+      // @ts-expect-error private member
+      expect(server.serverActiveCwd).toBe(normalizedAnyPath);
+      expect(mockProcessChdir).toHaveBeenCalledWith(normalizedAnyPath);
+      expect(result.metadata?.previousActiveDirectory).toBe(oldCwd);
+      expect(result.metadata?.newActiveDirectory).toBe(normalizedAnyPath);
+    });
   });
 });


### PR DESCRIPTION
This commit introduces a more explicit Current Working Directory (CWD) initialization mechanism for the server.

**Core Changes:**

- The server now maintains an internal state for its "active working directory" (`serverActiveCwd`).
- If the server starts with `security.restrictWorkingDirectory: true` and `security.allowedPaths` defined, and its launch directory (`process.cwd()`) is NOT compliant with `allowedPaths`, then `serverActiveCwd` remains uninitialized (`undefined`).
    - In this state, any attempt to execute a command that omits the `workingDir` parameter will be rejected, prompting you to first set a valid CWD.
    - Startup log messages have been added to inform you about this state and guide you.
- If the launch directory IS compliant, or if restrictions are not active, `serverActiveCwd` is initialized to the (normalized) `process.cwd()`.

**Tool Behavior Updates:**

- When executing commands:
    - I will use `serverActiveCwd` if `workingDir` is not provided.
    - I will return an error if `workingDir` is omitted and `serverActiveCwd` is `undefined`.
- When setting the current directory:
    - I will now explicitly set/update `serverActiveCwd` in addition to changing the process's current directory.
    - I will validate the target directory against `allowedPaths` before changing `serverActiveCwd` if restrictions are active.
- When getting the current directory:
    - I will return `serverActiveCwd` if defined.
    - I will return a specific message if `serverActiveCwd` is `undefined`.

**Testing:**

- I added new unit tests in `tests/cwdInitialization.test.ts` to cover:
    - `CLIServer` constructor logic for `serverActiveCwd` initialization under various configurations (restrictions enabled/disabled, launch CWD allowed/disallowed, empty/undefined `allowedPaths`).
    - Command execution behavior with and without `workingDir` when `serverActiveCwd` is defined or undefined.
    - Current directory retrieval behavior when `serverActiveCwd` is undefined.
    - A full interaction flow simulating server startup, CWD checks, and command execution.
- I updated existing tests in `tests/getConfig.test.ts` for getting and setting the current directory to align with the new logic and test `serverActiveCwd` updates and process directory changes.
- I mocked `process.cwd()`, `process.chdir()`, `console.error`, and `child_process.spawn` as needed for robust testing.

**Documentation:**

- I updated `README.md` with a new section explaining `serverActiveCwd`, its initialization, and implications for how I operate.
- I updated in-code descriptions for command execution, getting the current directory, and setting the current directory to reflect the new CWD handling.

This change makes the server's CWD state more transparent and guides you to establish a compliant working directory when necessary, enhancing security and usability.