### PR TITLE
Implement explicit CWD initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ It allows MCP clients (like [Claude Desktop](https://claude.ai/download)) to per
 - **Multi-Shell Support**: Execute commands in PowerShell, Command Prompt (CMD), and Git Bash
 - **Windows Subsystem for Linux (WSL)** support for command execution.
 - **Resource Exposure**: View current directory and configuration as MCP resources
+- **Explicit Working Directory State**: The server maintains an active working directory used when `execute_command` omits `workingDir`. If the launch directory isn't allowed, this state starts unset and must be set via `set_current_directory`.
 - **Security Controls**:
   - Command blocking (full paths, case variations)
   - Working directory validation
@@ -309,13 +310,14 @@ You can execute a series of commands in one request by joining them with `&&`. T
     - `command` (string): Command to execute
     - `workingDir` (optional string): Working directory
   - Returns command output as text, or error message if execution fails
+  - If `workingDir` is omitted, the command runs in the server's active working directory. If this has not been set, the tool returns an error.
 
 - **get_current_directory**
-  - Get the current working directory of the server
-  - Returns the current working directory path
+  - Get the server's active working directory
+  - If the directory is not set, returns a message explaining how to set it
 
 - **set_current_directory**
-  - Set the current working directory of the server
+  - Set the server's active working directory
   - Inputs:
     - `path` (string): Path to set as current working directory
   - Returns confirmation message with the new directory path, or error message if the change fails

--- a/tests/serverCwdInitialization.test.ts
+++ b/tests/serverCwdInitialization.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { CLIServer } from '../src/index.js';
+import { buildTestConfig } from './helpers/testUtils.js';
+
+const ALLOWED_DIR = 'C:\\allowed';
+const OUTSIDE_DIR = 'C:\\not\\allowed';
+
+describe('Server active working directory initialization', () => {
+  test('launch outside allowed paths leaves active cwd undefined', () => {
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(OUTSIDE_DIR);
+    const config = buildTestConfig({ security: { allowedPaths: [ALLOWED_DIR], restrictWorkingDirectory: true } });
+    const server = new CLIServer(config);
+    expect((server as any).serverActiveCwd).toBeUndefined();
+    cwdSpy.mockRestore();
+  });
+
+  test('execute_command without workingDir fails when active cwd undefined', async () => {
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(OUTSIDE_DIR);
+    const config = buildTestConfig({ security: { allowedPaths: [ALLOWED_DIR], restrictWorkingDirectory: true } });
+    const server = new CLIServer(config);
+    const res = await server._executeTool({ name: 'execute_command', arguments: { shell: 'wsl', command: 'echo hi' } });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/active working directory is not set/i);
+    cwdSpy.mockRestore();
+  });
+
+  test('set_current_directory sets active cwd', async () => {
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(OUTSIDE_DIR);
+    const chdirSpy = jest.spyOn(process, 'chdir').mockImplementation(() => {});
+    const config = buildTestConfig({ security: { allowedPaths: [ALLOWED_DIR], restrictWorkingDirectory: true } });
+    const server = new CLIServer(config);
+    const res = await server._executeTool({ name: 'set_current_directory', arguments: { path: ALLOWED_DIR } });
+    expect(res.isError).toBe(false);
+    expect((server as any).serverActiveCwd).toBe(ALLOWED_DIR);
+    expect(chdirSpy).toHaveBeenCalledWith(ALLOWED_DIR);
+    chdirSpy.mockRestore();
+    cwdSpy.mockRestore();
+  });
+
+  test('get_current_directory reports unset state', async () => {
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(OUTSIDE_DIR);
+    const config = buildTestConfig({ security: { allowedPaths: [ALLOWED_DIR], restrictWorkingDirectory: true } });
+    const server = new CLIServer(config);
+    const res = await server._executeTool({ name: 'get_current_directory', arguments: {} });
+    expect(res.isError).toBe(false);
+    expect(res.content[0].text).toMatch(/not currently set/i);
+    cwdSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- keep explicit server active working directory
- fall back to set_current_directory when not initialized
- document active working directory behaviour
- test explicit CWD initialization scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68453c4542c883208a61536c7be6a2bc