### PR TITLE
Add initialDir config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It allows MCP clients (like [Claude Desktop](https://claude.ai/download)) to per
 - **Windows Subsystem for Linux (WSL)** support for command execution.
 - **Resource Exposure**: View current directory and configuration as MCP resources
 - **Explicit Working Directory State**: The server maintains an active working directory used when `execute_command` omits `workingDir`. If the launch directory isn't allowed, this state starts unset and must be set via `set_current_directory`.
+- **Optional Initial Directory**: Configure `initialDir` to start the server in a specific directory.
 - **Security Controls**:
   - Command blocking (full paths, case variations)
   - Working directory validation
@@ -152,6 +153,7 @@ If no configuration file is found, the server will use a default (restricted) co
       "--login",
       "--system"
     ],
+    "initialDir": null,
     "allowedPaths": ["User's home directory", "Current working directory"],
     "restrictWorkingDirectory": true,
     "commandTimeout": 30,
@@ -230,6 +232,9 @@ The configuration file is divided into two main sections: `security` and `shells
       "--login", // Login shells might have different permissions
       "--system" // System level operations
     ],
+
+    // Optional starting directory for the server
+    "initialDir": null,
 
     // List of directories where commands can be executed
     "allowedPaths": ["C:\\Users\\YourUsername", "C:\\Projects"],

--- a/TEST_DESCRIPTIONS.md
+++ b/TEST_DESCRIPTIONS.md
@@ -41,6 +41,24 @@ This document summarizes the purpose of each unit test in the project.
 - **createSerializableConfig returns consistent config structure** – checks that the structure of the serialized config always contains the necessary keys for security and shell settings.
 - **get_config tool response format** – ensures the response format produced by the configuration tool is correctly shaped and contains the serialized config.
 
+## tests/initialDirConfig.test.ts
+
+- **valid initialDir with restriction adds to allowedPaths** – verifies that a provided initial directory is normalized and added to `allowedPaths` when `restrictWorkingDirectory` is true.
+- **valid initialDir without restriction leaves allowedPaths unchanged** – ensures the path is normalized but not appended when restrictions are disabled.
+- **invalid initialDir logs warning and is unset** – an invalid path triggers a warning and the setting becomes `undefined`.
+- **initialDir omitted results in undefined** – confirms the default when no `initialDir` is specified.
+- **non-string initialDir logs warning and is unset** – non-string values produce a warning and are ignored.
+
+## tests/serverCwdInitialization.test.ts
+
+- **launch outside allowed paths leaves cwd undefined** – starting the server in a disallowed directory results in no active working directory.
+- **execute_command fails when cwd undefined** – commands without a workingDir return an error when no active directory is set.
+- **set_current_directory sets active cwd** – using the tool successfully changes the active directory and calls `process.chdir`.
+- **get_current_directory reports unset state** – retrieving the current directory before one is set returns a helpful message.
+- **initialDir sets active cwd when valid** – a valid `initialDir` is used at startup and becomes the active directory.
+- **initialDir chdir failure falls back to process.cwd()** – if changing to `initialDir` fails the server falls back to the process directory.
+- **initialDir not in allowedPaths leaves active cwd undefined** – when restrictions prevent using the configured `initialDir`, the active directory remains unset.
+
 ## tests/toolDescription.test.ts
 
 - **generates correct description with all shells enabled** – checks that the tool description lists every enabled shell and includes example blocks for each.

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -6,6 +6,7 @@ export interface SecurityConfig {
   restrictWorkingDirectory: boolean;
   commandTimeout: number;
   enableInjectionProtection: boolean;
+  initialDir?: string;
 }
 
 export interface ShellConfig {

--- a/tests/initialDirConfig.test.ts
+++ b/tests/initialDirConfig.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { loadConfig } from '../src/utils/config.js';
+import { normalizeWindowsPath } from '../src/utils/validation.js';
+
+const createTempConfig = (config: any): string => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'win-cli-initdir-'));
+  const configPath = path.join(tempDir, 'config.json');
+  fs.writeFileSync(configPath, JSON.stringify(config));
+  return configPath;
+};
+
+describe('loadConfig initialDir handling', () => {
+  test('valid initialDir with restrictWorkingDirectory true', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'valid-dir-'));
+    const configPath = createTempConfig({ security: { initialDir: dir, restrictWorkingDirectory: true } });
+    const cfg = loadConfig(configPath);
+    const normalized = normalizeWindowsPath(dir);
+    expect(cfg.security.initialDir).toBe(normalized);
+    expect(cfg.security.allowedPaths).toContain(normalized.toLowerCase());
+    fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('valid initialDir with restrictWorkingDirectory false', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'valid-dir-'));
+    const configPath = createTempConfig({ security: { initialDir: dir, restrictWorkingDirectory: false } });
+    const cfg = loadConfig(configPath);
+    const normalized = normalizeWindowsPath(dir);
+    expect(cfg.security.initialDir).toBe(normalized);
+    expect(cfg.security.allowedPaths).not.toContain(normalized.toLowerCase());
+    fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('invalid initialDir logs warning and is undefined', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const configPath = createTempConfig({ security: { initialDir: '/nonexistent/path', restrictWorkingDirectory: true } });
+    const cfg = loadConfig(configPath);
+    expect(cfg.security.initialDir).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+    fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+    warnSpy.mockRestore();
+  });
+
+  test('initialDir not provided results in undefined', () => {
+    const configPath = createTempConfig({ security: { } });
+    const cfg = loadConfig(configPath);
+    expect(cfg.security.initialDir).toBeUndefined();
+    fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+  });
+
+  test('non-string initialDir logs warning and is undefined', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const configPath = createTempConfig({ security: { initialDir: null } });
+    const cfg = loadConfig(configPath);
+    expect(cfg.security.initialDir).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+    fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- introduce optional `initialDir` setting in config types and defaults
- process `initialDir` in config loader and include in allowedPaths
- initialize server CWD using `initialDir` and handle fallback cases
- test handling of `initialDir` in config loader and server initialization
- document `initialDir` option and new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68454418695c8320b00f813a8e3c4ee1