### PR TITLE
Implement conditional WSL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ If no configuration file is found, the server will use a default (restricted) co
     "allowedPaths": ["User's home directory", "Current working directory"],
     "restrictWorkingDirectory": true,
     "commandTimeout": 30,
-    "enableInjectionProtection": true
+    "enableInjectionProtection": true,
+    "includeDefaultWSL": false
   },
   "shells": {
     "powershell": {
@@ -176,12 +177,6 @@ If no configuration file is found, the server will use a default (restricted) co
       "enabled": true,
       "command": "C:\\Program Files\\Git\\bin\\bash.exe",
       "args": ["-c"],
-      "blockedOperators": ["&", "|", ";", "`"]
-    },
-    "wsl": {
-      "enabled": true,
-      "command": "wsl.exe",
-      "args": ["-e"],
       "blockedOperators": ["&", "|", ";", "`"]
     }
   }
@@ -277,12 +272,34 @@ The configuration file is divided into two main sections: `security` and `shells
       "command": "C:\\Program Files\\Git\\bin\\bash.exe",
       "args": ["-c"],
       "blockedOperators": ["&", "|", ";", "`"]  // Block all command chaining
-    },
+    }
+  }
+}
+```
+
+### WSL Configuration
+
+WSL support is optional. The server includes WSL settings only when your `config.json` contains a `wsl` shell configuration or the `includeDefaultWSL` flag is set to `true` in the security section.
+
+Enable the default WSL configuration:
+
+```json
+{
+  "security": {
+    "includeDefaultWSL": true
+  }
+}
+```
+
+Or provide custom WSL settings:
+
+```json
+{
+  "shells": {
     "wsl": {
       "enabled": true,
-      "command": "wsl.exe", // Command to invoke WSL
-      "args": ["-e"],       // Arguments to pass to wsl.exe for command execution (e.g., '-e' to execute a command)
-      "blockedOperators": ["&", "|", ";", "`"] // Standard blocked operators
+      "command": "wsl.exe",
+      "args": ["-e"]
     }
   }
 }

--- a/config.sample.json
+++ b/config.sample.json
@@ -19,7 +19,8 @@
     "allowedPaths": ["C:\\Users\\YourUsername", "C:\\Projects"],
     "restrictWorkingDirectory": true,
     "commandTimeout": 30,
-    "enableInjectionProtection": true
+    "enableInjectionProtection": true,
+    "includeDefaultWSL": false
   },
   "shells": {
     "powershell": {
@@ -38,12 +39,6 @@
       "enabled": true,
       "command": "C:\\Program Files\\Git\\bin\\bash.exe",
       "args": ["-c"],
-      "blockedOperators": ["&", "|", ";", "`"]
-    },
-    "wsl": {
-      "enabled": true,
-      "command": "wsl.exe",
-      "args": ["-e"],
       "blockedOperators": ["&", "|", ";", "`"]
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -340,7 +340,13 @@ class CLIServer {
           }
 
           const shellKey = args.shell as keyof typeof this.config.shells;
-          const shellConfig = this.config.shells[shellKey]!; // Assert non-null: shellKey from enum of enabled shells
+          const shellConfig = this.config.shells[shellKey];
+          if (!shellConfig) {
+            throw new McpError(
+              ErrorCode.InvalidRequest,
+              `Shell '${shellKey}' is not configured or enabled`
+            );
+          }
 
           if (this.config.security.restrictWorkingDirectory) {
             try {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -7,6 +7,7 @@ export interface SecurityConfig {
   commandTimeout: number;
   enableInjectionProtection: boolean;
   initialDir?: string;
+  includeDefaultWSL?: boolean;
 }
 
 export interface ShellConfig {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -182,7 +182,10 @@ export function convertWindowsToWslPath(windowsPath: string, mountPoint: string 
   return windowsPath;
 }
 
-export function resolveWslAllowedPaths(globalAllowedPaths: string[], wslConfig: ShellConfig): string[] {
+export function resolveWslAllowedPaths(globalAllowedPaths: string[], wslConfig?: ShellConfig): string[] {
+  if (!wslConfig) {
+    return [];
+  }
   const wslPaths: string[] = [];
   const mountPoint = wslConfig.wslMountPoint || '/mnt/';
 
@@ -248,7 +251,10 @@ export function isWslPathAllowed(testPath: string, allowedPaths: string[]): bool
   });
 }
 
-export function validateWslWorkingDirectory(dir: string, wslConfig: ShellConfig, globalAllowedPaths: string[]): void {
+export function validateWslWorkingDirectory(dir: string, wslConfig: ShellConfig | undefined, globalAllowedPaths: string[]): void {
+  if (!wslConfig) {
+    throw new Error('WSL shell is not configured');
+  }
   // Ensure dir is an absolute WSL/Linux-style path
   if (!path.posix.isAbsolute(dir)) {
       throw new Error('WSL working directory must be an absolute path (e.g., /mnt/c/Users or /home/user)');

--- a/tests/helpers/TestCLIServer.ts
+++ b/tests/helpers/TestCLIServer.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { CLIServer } from '../../src/index.js';
-import { DEFAULT_CONFIG } from '../../src/utils/config.js';
+import { DEFAULT_CONFIG, DEFAULT_WSL_CONFIG } from '../../src/utils/config.js';
 import type { ServerConfig } from '../../src/types/config.js';
 
 export class TestCLIServer {
@@ -11,13 +11,13 @@ export class TestCLIServer {
 
     // Configure wsl shell to use the local emulator script
     const wslEmulatorPath = path.resolve(process.cwd(), 'scripts/wsl.sh');
-    baseConfig.shells.wsl = {
-      enabled: true,
-      command: 'bash', // Use bash to execute the script
-      args: [wslEmulatorPath, '-e'], // Pass script path as first arg to bash
-      validatePath: (dir: string) => /^(\/mnt\/[a-zA-Z]\/|\/)/.test(dir),
-      blockedOperators: ['&', '|', ';', '`']
+    const wslShell = {
+      ...DEFAULT_WSL_CONFIG,
+      command: 'bash',
+      args: [wslEmulatorPath, '-e']
     };
+    baseConfig.shells = { ...baseConfig.shells, wsl: wslShell };
+    baseConfig.security.includeDefaultWSL = true;
 
     // Disable other shells by default for cross platform reliability
     baseConfig.shells.powershell.enabled = false;

--- a/tests/helpers/testUtils.ts
+++ b/tests/helpers/testUtils.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CONFIG } from '../../src/utils/config.js';
+import { DEFAULT_CONFIG, DEFAULT_WSL_CONFIG } from '../../src/utils/config.js';
 import type { ServerConfig, ShellConfig } from '../../src/types/config.js';
 
 /**
@@ -29,9 +29,9 @@ export function buildTestConfig(overrides: Partial<ServerConfig> = {}): ServerCo
       powershell: mergeShellConfig(DEFAULT_CONFIG.shells.powershell, overrides.shells?.powershell),
       cmd: mergeShellConfig(DEFAULT_CONFIG.shells.cmd, overrides.shells?.cmd),
       gitbash: mergeShellConfig(DEFAULT_CONFIG.shells.gitbash, overrides.shells?.gitbash),
-      // DEFAULT_CONFIG.shells.wsl is guaranteed to be a ShellConfig by its definition in DEFAULT_CONFIG
-      // The non-null assertion operator (!) is safe here.
-      wsl: mergeShellConfig(DEFAULT_CONFIG.shells.wsl!, overrides.shells?.wsl), 
+      ...(overrides.shells?.wsl || overrides.security?.includeDefaultWSL || DEFAULT_CONFIG.security.includeDefaultWSL ? {
+        wsl: mergeShellConfig(DEFAULT_WSL_CONFIG, overrides.shells?.wsl)
+      } : {})
     },
   };
 }

--- a/tests/serverCwdInitialization.test.ts
+++ b/tests/serverCwdInitialization.test.ts
@@ -8,7 +8,9 @@ const OUTSIDE_DIR = 'C:\\not\\allowed';
 describe('Server active working directory initialization', () => {
   test('launch outside allowed paths leaves active cwd undefined', () => {
     const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(OUTSIDE_DIR);
-    const config = buildTestConfig({ security: { allowedPaths: [ALLOWED_DIR], restrictWorkingDirectory: true } });
+    const config = buildTestConfig({
+      security: { allowedPaths: [ALLOWED_DIR], restrictWorkingDirectory: true, includeDefaultWSL: true }
+    });
     const server = new CLIServer(config);
     expect((server as any).serverActiveCwd).toBeUndefined();
     cwdSpy.mockRestore();
@@ -16,7 +18,9 @@ describe('Server active working directory initialization', () => {
 
   test('execute_command without workingDir fails when active cwd undefined', async () => {
     const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(OUTSIDE_DIR);
-    const config = buildTestConfig({ security: { allowedPaths: [ALLOWED_DIR], restrictWorkingDirectory: true } });
+    const config = buildTestConfig({
+      security: { allowedPaths: [ALLOWED_DIR], restrictWorkingDirectory: true, includeDefaultWSL: true }
+    });
     const server = new CLIServer(config);
     const res = await server._executeTool({ name: 'execute_command', arguments: { shell: 'wsl', command: 'echo hi' } });
     expect(res.isError).toBe(true);


### PR DESCRIPTION
## Summary
- add optional `includeDefaultWSL` security flag
- provide separate `DEFAULT_WSL_CONFIG` and remove WSL from defaults
- merge WSL settings only when requested
- guard command execution when WSL is not configured
- update helpers and tests for optional WSL
- document optional WSL configuration and update samples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68455a6fc9688320893adf0cbf08a5d3