### PR TITLE
Implement conditional shell configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,21 @@ The configuration file is divided into two main sections: `security` and `shells
 
 #### Shell Configuration
 
+**Important Note:** Shells must be explicitly configured to be included. Only shells specified in your `config.json` will be available.
+
+Example minimal configuration enabling only Git Bash:
+```json
+{
+  "shells": {
+    "gitbash": {
+      "enabled": true,
+      "command": "C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+      "args": ["-c"]
+    }
+  }
+}
+```
+
 ```json
 {
   "shells": {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -24,9 +24,9 @@ export interface ShellConfig {
 export interface ServerConfig {
   security: SecurityConfig;
   shells: {
-    powershell: ShellConfig;
-    cmd: ShellConfig;
-    gitbash: ShellConfig;
+    powershell?: ShellConfig;
+    cmd?: ShellConfig;
+    gitbash?: ShellConfig;
     wsl?: ShellConfig;
   };
 }

--- a/tests/conditionalShells.test.ts
+++ b/tests/conditionalShells.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from '@jest/globals';
+import { loadConfig } from '../src/utils/config.js';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const createTempConfig = (config: any): string => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'win-cli-shell-test-'));
+  const configPath = path.join(tempDir, 'config.json');
+  fs.writeFileSync(configPath, JSON.stringify(config));
+  return configPath;
+};
+
+describe('Conditional Shell Configuration', () => {
+  test('WSL behavior unchanged with includeDefaultWSL', () => {
+    const configPath = createTempConfig({
+      security: { includeDefaultWSL: true }
+    });
+
+    const cfg = loadConfig(configPath);
+
+    expect(cfg.shells).toHaveProperty('wsl');
+    expect(cfg.shells).not.toHaveProperty('powershell');
+    expect(cfg.shells).not.toHaveProperty('cmd');
+    expect(cfg.shells).not.toHaveProperty('gitbash');
+
+    fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+  });
+
+  test('backward compatibility with full shell specification', () => {
+    const configPath = createTempConfig({
+      shells: {
+        powershell: { enabled: true },
+        cmd: { enabled: true },
+        gitbash: { enabled: true },
+        wsl: { enabled: true }
+      }
+    });
+
+    const cfg = loadConfig(configPath);
+
+    expect(cfg.shells).toHaveProperty('powershell');
+    expect(cfg.shells).toHaveProperty('cmd');
+    expect(cfg.shells).toHaveProperty('gitbash');
+    expect(cfg.shells).toHaveProperty('wsl');
+
+    fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+  });
+
+  test('shell validatePath and blockedOperators properly assigned', () => {
+    const configPath = createTempConfig({
+      shells: {
+        gitbash: { enabled: true }
+      }
+    });
+
+    const cfg = loadConfig(configPath);
+
+    expect(cfg.shells.gitbash?.validatePath).toBeDefined();
+    expect(cfg.shells.gitbash?.blockedOperators).toBeDefined();
+    expect(cfg.shells.gitbash?.blockedOperators).toEqual(['&', '|', ';', '`']);
+
+    fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+  });
+});

--- a/tests/configNormalization.test.ts
+++ b/tests/configNormalization.test.ts
@@ -63,4 +63,56 @@ describe('Config Normalization', () => {
 
     fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
   });
+
+  test('minimal config only includes specified shells', () => {
+    const partialConfig = {
+      shells: {
+        gitbash: {
+          enabled: true,
+          command: "C:\\Program Files\\Git\\usr\\bin\\bash.exe"
+        }
+      }
+    };
+
+    const configPath = createTempConfig(partialConfig);
+    const cfg = loadConfig(configPath);
+
+    expect(cfg.shells).toHaveProperty('gitbash');
+    expect(cfg.shells).not.toHaveProperty('powershell');
+    expect(cfg.shells).not.toHaveProperty('cmd');
+    expect(cfg.shells).not.toHaveProperty('wsl');
+
+    fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+  });
+
+  test('empty shells config results in no shells', () => {
+    const configPath = createTempConfig({
+      security: { allowedPaths: ['C\\test'] }
+    });
+
+    const cfg = loadConfig(configPath);
+
+    expect(Object.keys(cfg.shells)).toHaveLength(0);
+
+    fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+  });
+
+  test('multiple shells config includes only specified shells', () => {
+    const partialConfig = {
+      shells: {
+        powershell: { enabled: false },
+        cmd: { enabled: true }
+      }
+    };
+
+    const configPath = createTempConfig(partialConfig);
+    const cfg = loadConfig(configPath);
+
+    expect(cfg.shells).toHaveProperty('powershell');
+    expect(cfg.shells).toHaveProperty('cmd');
+    expect(cfg.shells).not.toHaveProperty('gitbash');
+    expect(cfg.shells).not.toHaveProperty('wsl');
+
+    fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+  });
 });

--- a/tests/getConfig.test.ts
+++ b/tests/getConfig.test.ts
@@ -116,6 +116,20 @@ describe('get_config tool', () => {
     });
 
   });
+
+  test('createSerializableConfig handles empty shells config', () => {
+    const testConfigMinimal: ServerConfig = {
+      security: { ...testConfig.security },
+      shells: {}
+    };
+
+    const safeConfig = createSerializableConfig(testConfigMinimal);
+
+    expect(safeConfig).toBeDefined();
+    expect(safeConfig.security).toBeDefined();
+    expect(safeConfig.shells).toBeDefined();
+    expect(Object.keys(safeConfig.shells)).toHaveLength(0);
+  });
   
   test('get_config tool response format', () => {
     // Call the utility function directly with our test config


### PR DESCRIPTION
## Summary
- enable conditional merging of shell config
- update type definitions
- document explicit shell configuration requirement
- add tests for conditional shell behavior

## Testing
- `npm test`
- `npm test tests/conditionalShells.test.ts`
- `npm test tests/configNormalization.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6845664b18108320860ec0a659a7e25a