### PR TITLE
Remove deprecated includeDefaultWSL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,7 @@ If no configuration file is found, the server will use a default (restricted) co
     "allowedPaths": ["User's home directory", "Current working directory"],
     "restrictWorkingDirectory": true,
     "commandTimeout": 30,
-    "enableInjectionProtection": true,
-    "includeDefaultWSL": false
+    "enableInjectionProtection": true
   },
   "shells": {
     "powershell": {
@@ -294,19 +293,7 @@ Example minimal configuration enabling only Git Bash:
 
 ### WSL Configuration
 
-WSL support is optional. The server includes WSL settings only when your `config.json` contains a `wsl` shell configuration or the `includeDefaultWSL` flag is set to `true` in the security section.
-
-Enable the default WSL configuration:
-
-```json
-{
-  "security": {
-    "includeDefaultWSL": true
-  }
-}
-```
-
-Or provide custom WSL settings:
+WSL support is optional. To enable WSL, add it to your shell configuration:
 
 ```json
 {

--- a/TEST_DESCRIPTIONS.md
+++ b/TEST_DESCRIPTIONS.md
@@ -16,9 +16,7 @@ This document summarizes the purpose of each unit test in the project.
 - **allows changing directory outside allowed paths when restriction disabled** – confirms unrestricted working directory settings allow `cd` into disallowed paths.
 - **rejects changing directory outside allowed paths when restriction enabled** – checks that enabling the restriction prevents `cd` to directories beyond the allowed list.
 
-## tests/conditionalShells.test.ts
-
-- **includeDefaultWSL adds only WSL shell** – enabling `includeDefaultWSL` results in a configuration containing only the WSL shell.
+- **WSL only included with explicit configuration** – ensures the WSL shell is available only when the `wsl` shell is specified in configuration.
 - **backward compatibility with explicit shell list** – specifying all shells explicitly retains each shell entry in the loaded config.
 - **assigns validatePath and blockedOperators for shells** – enabled shells have default path validators and blocked operator lists populated.
 
@@ -26,6 +24,7 @@ This document summarizes the purpose of each unit test in the project.
 
 - **loadConfig lower-cases and normalizes allowedPaths** – tests that loading configuration normalizes path casing and formats allowed paths consistently.
 - **loadConfig fills missing security settings with defaults** – verifies that any security settings not supplied in the config file are populated with default values.
+- **includeDefaultWSL setting is ignored (deprecated)** – ensures deprecated `includeDefaultWSL` in the security section does not enable WSL.
 
 ## tests/directoryValidator.test.ts
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -19,8 +19,7 @@
     "allowedPaths": ["C:\\Users\\YourUsername", "C:\\Projects"],
     "restrictWorkingDirectory": true,
     "commandTimeout": 30,
-    "enableInjectionProtection": true,
-    "includeDefaultWSL": false
+    "enableInjectionProtection": true
   },
   "shells": {
     "powershell": {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -7,7 +7,7 @@ export interface SecurityConfig {
   commandTimeout: number;
   enableInjectionProtection: boolean;
   initialDir?: string;
-  includeDefaultWSL?: boolean;
+  // includeDefaultWSL removed - use explicit shells.wsl configuration instead
 }
 
 export interface ShellConfig {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -39,8 +39,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
     ],
     restrictWorkingDirectory: true,
     commandTimeout: 30,
-    enableInjectionProtection: true,
-    includeDefaultWSL: false
+    enableInjectionProtection: true
   },
   shells: {
     powershell: {
@@ -136,14 +135,14 @@ function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<ServerCon
     shells: {}
   };
 
+  // Remove deprecated includeDefaultWSL if present
+  delete (merged.security as any).includeDefaultWSL;
+
   // Determine which shells should be included
   const shouldIncludePowerShell = userConfig.shells?.powershell !== undefined;
   const shouldIncludeCmd = userConfig.shells?.cmd !== undefined;
   const shouldIncludeGitBash = userConfig.shells?.gitbash !== undefined;
-  const shouldIncludeWSL =
-    userConfig.shells?.wsl !== undefined ||
-    merged.security.includeDefaultWSL === true ||
-    userConfig.security?.includeDefaultWSL === true;
+  const shouldIncludeWSL = userConfig.shells?.wsl !== undefined;
 
   if (shouldIncludePowerShell) {
     merged.shells.powershell = {

--- a/tests/conditionalShells.test.ts
+++ b/tests/conditionalShells.test.ts
@@ -12,14 +12,17 @@ const createTempConfig = (config: any): string => {
 };
 
 describe('Conditional Shell Configuration', () => {
-  test('WSL behavior unchanged with includeDefaultWSL', () => {
+  test('WSL only included with explicit shells.wsl configuration', () => {
     const configPath = createTempConfig({
-      security: { includeDefaultWSL: true }
+      shells: {
+        wsl: { enabled: true }
+      }
     });
 
     const cfg = loadConfig(configPath);
 
     expect(cfg.shells).toHaveProperty('wsl');
+    expect(cfg.shells.wsl?.enabled).toBe(true);
     expect(cfg.shells).not.toHaveProperty('powershell');
     expect(cfg.shells).not.toHaveProperty('cmd');
     expect(cfg.shells).not.toHaveProperty('gitbash');

--- a/tests/configNormalization.test.ts
+++ b/tests/configNormalization.test.ts
@@ -115,4 +115,20 @@ describe('Config Normalization', () => {
 
     fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
   });
+
+  test('includeDefaultWSL setting is ignored (deprecated)', () => {
+    const configPath = createTempConfig({
+      security: {
+        includeDefaultWSL: true,
+        allowedPaths: ['C\\test']
+      }
+    });
+
+    const cfg = loadConfig(configPath);
+
+    expect(cfg.shells).not.toHaveProperty('wsl');
+    expect(cfg.security).not.toHaveProperty('includeDefaultWSL');
+
+    fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+  });
 });

--- a/tests/helpers/TestCLIServer.ts
+++ b/tests/helpers/TestCLIServer.ts
@@ -17,7 +17,6 @@ export class TestCLIServer {
       args: [wslEmulatorPath, '-e']
     };
     baseConfig.shells = { ...baseConfig.shells, wsl: wslShell };
-    baseConfig.security.includeDefaultWSL = true;
 
     // Disable other shells by default for cross platform reliability
     baseConfig.shells.powershell.enabled = false;

--- a/tests/helpers/testUtils.ts
+++ b/tests/helpers/testUtils.ts
@@ -29,7 +29,7 @@ export function buildTestConfig(overrides: Partial<ServerConfig> = {}): ServerCo
       powershell: mergeShellConfig(DEFAULT_CONFIG.shells.powershell, overrides.shells?.powershell),
       cmd: mergeShellConfig(DEFAULT_CONFIG.shells.cmd, overrides.shells?.cmd),
       gitbash: mergeShellConfig(DEFAULT_CONFIG.shells.gitbash, overrides.shells?.gitbash),
-      ...(overrides.shells?.wsl || overrides.security?.includeDefaultWSL || DEFAULT_CONFIG.security.includeDefaultWSL ? {
+      ...(overrides.shells?.wsl ? {
         wsl: mergeShellConfig(DEFAULT_WSL_CONFIG, overrides.shells?.wsl)
       } : {})
     },

--- a/tests/serverCwdInitialization.test.ts
+++ b/tests/serverCwdInitialization.test.ts
@@ -9,7 +9,8 @@ describe('Server active working directory initialization', () => {
   test('launch outside allowed paths leaves active cwd undefined', () => {
     const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(OUTSIDE_DIR);
     const config = buildTestConfig({
-      security: { allowedPaths: [ALLOWED_DIR], restrictWorkingDirectory: true, includeDefaultWSL: true }
+      security: { allowedPaths: [ALLOWED_DIR], restrictWorkingDirectory: true },
+      shells: { wsl: { enabled: true } }
     });
     const server = new CLIServer(config);
     expect((server as any).serverActiveCwd).toBeUndefined();
@@ -19,7 +20,8 @@ describe('Server active working directory initialization', () => {
   test('execute_command without workingDir fails when active cwd undefined', async () => {
     const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(OUTSIDE_DIR);
     const config = buildTestConfig({
-      security: { allowedPaths: [ALLOWED_DIR], restrictWorkingDirectory: true, includeDefaultWSL: true }
+      security: { allowedPaths: [ALLOWED_DIR], restrictWorkingDirectory: true },
+      shells: { wsl: { enabled: true } }
     });
     const server = new CLIServer(config);
     const res = await server._executeTool({ name: 'execute_command', arguments: { shell: 'wsl', command: 'echo hi' } });


### PR DESCRIPTION
## Summary
- drop `includeDefaultWSL` option from security config
- simplify default config and merge logic
- adjust documentation and sample config
- update tests and helpers for new behaviour

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845ae7a22508320a033d8c93ba14e12