### PR TITLE
Fix path normalization for single backslashes

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -316,6 +316,14 @@ export function validateWorkingDirectory(dir: string, allowedPaths: string[]): v
     }
 }
 
+/**
+ * Normalizes Windows paths to a consistent format
+ * - Git Bash paths (/c/foo) → C:\\foo
+ * - WSL paths (/mnt/..., /home/...) → preserved with forward slashes
+ * - Single backslash paths (\\Users) → C:\\Users (relative to system drive)
+ * - UNC paths (\\\\server\\share) → preserved
+ * - Relative paths → resolved relative to C:\\
+ */
 export function normalizeWindowsPath(inputPath: string): string {
     // TEMPORARILY simplified for diagnostics, with WSL path distinction
     // console.log(`normalizeWindowsPath (simplified) INPUT: '${inputPath}'`);
@@ -359,6 +367,11 @@ export function normalizeWindowsPath(inputPath: string): string {
     else {
         // Convert any forward slashes to backslashes for Windows paths
         tempPath = tempPath.replace(/\//g, '\\');
+
+        // Handle paths starting with a single backslash (e.g. \Users\foo)
+        if (tempPath.startsWith('\\') && !tempPath.startsWith('\\\\')) {
+            tempPath = 'C:' + tempPath;
+        }
     }
 
     // --- Windows Path Resolution and Normalization ---

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -153,6 +153,15 @@ describe('Path Normalization', () => {
     ['\\\\server\\share\\file', '\\\\server\\share\\file'],
     ['//server/share/folder', '/server/share/folder'],  // Fixed: UNC from // isn't handled the same
 
+    // Single backslash paths relative to system drive
+    ['\\Program Files\\App', 'C:\\Program Files\\App'],
+    ['\\Windows', 'C:\\Windows'],
+    ['\\', 'C:\\'],
+
+    // Ensure UNC paths still handled
+    ['\\\\server\\share', '\\\\server\\share'],
+    ['\\\\192.168.1.1\\folder', '\\\\192.168.1.1\\folder'],
+
     // WSL paths (preserved)
     ['/mnt/c/foo/bar', '/mnt/c/foo/bar'],
     ['/mnt/d/', '/mnt/d/'],


### PR DESCRIPTION
## Summary
- handle single backslash paths in `normalizeWindowsPath`
- document `normalizeWindowsPath` behaviour
- add regression tests for single-backslash paths

## Testing
- `npm test tests/validation.test.ts -- --testNamePattern="normalizeWindowsPath.*Users.*test"`
- `npm test tests/validation.test.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845e98d16f48320bbfbaf7cc258c1c0