### PR TITLE
Fix integration async tests with enhanced wsl emulator

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,23 @@
+# Test Suite Documentation
+
+## WSL Testing
+
+The test suite uses a Node.js-based WSL emulator (`scripts/wsl-emulator.js`) to enable cross-platform testing of WSL functionality.
+
+### Emulated Commands
+
+The emulator provides special handling for common test commands:
+- `pwd`: Returns the current working directory
+- `echo`: Outputs arguments
+- `ls /tmp`: Simulates temporary directory listing
+- `ls /mnt/c`: Simulates non-existent mount error
+- `exit N`: Exits with specified code
+- `uname -a`: Returns Linux system information
+
+### Test Configuration
+
+All WSL tests should use the Node.js emulator:
+```typescript
+command: 'node',
+args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e']
+```

--- a/tests/wslEmulator.test.ts
+++ b/tests/wslEmulator.test.ts
@@ -16,4 +16,21 @@ describe('WSL Emulator Functionality', () => {
     const result = spawnSync('node', [wslEmulatorPath, '-e', 'exit', '42']);
     expect(result.status).toBe(42);
   });
+
+  test('pwd returns current directory', () => {
+    const result = spawnSync('node', [wslEmulatorPath, '-e', 'pwd'], {
+      encoding: 'utf8',
+      cwd: '/tmp'
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('/tmp');
+  });
+
+  test('ls /tmp returns simulated output', () => {
+    const result = spawnSync('node', [wslEmulatorPath, '-e', 'ls', '/tmp'], {
+      encoding: 'utf8'
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('total 0');
+  });
 });


### PR DESCRIPTION
## Summary
- extend wsl-emulator with handling for pwd, ls, echo, uname and exit
- update TestCLIServer helper to use emulator config consistently
- add README for test suite explaining emulator usage
- expand wslEmulator tests

## Testing
- `npm test tests/wslEmulator.test.ts`
- `npm test tests/integration`
- `npm test tests/asyncOperations.test.ts`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845f53cd6008320844ee71af60b0776