### PR TITLE
Fix directory validator tests

### DIFF
--- a/src/utils/directoryValidator.ts
+++ b/src/utils/directoryValidator.ts
@@ -40,7 +40,10 @@ export function validateDirectories(directories: string[], allowedPaths: string[
  * Validates directories and throws an error if any are not allowed
  * @param directories List of directories to validate
  * @param allowedPaths List of allowed paths
- * @throws McpError if any directory is not allowed
+ * @throws McpError with detailed message including:
+ *   - Which directories are invalid
+ *   - What the allowed paths are
+ *   - Clear indication that commands cannot execute
  */
 export function validateDirectoriesAndThrow(directories: string[], allowedPaths: string[]): void {
   const result = validateDirectories(directories, allowedPaths);

--- a/tests/directoryValidator.test.ts
+++ b/tests/directoryValidator.test.ts
@@ -90,5 +90,24 @@ const allowedPaths = ['C:\\Users\\test', 'D:\\Projects'];
           message: expect.stringMatching(new RegExp(expectedParts.join('.*'), 'i'))
         }));
     });
+
+    test('error message has correct structure and includes all information', () => {
+      const invalidDirs = ['C\\Invalid\\Path'];
+      const allowed = ['C\\Allowed\\Path1', 'D\\Allowed\\Path2'];
+
+      try {
+        validateDirectoriesAndThrow(invalidDirs, allowed);
+        fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(McpError);
+        expect(error.code).toBe(ErrorCode.InvalidRequest);
+        expect(error.message).toContain('MCP error -32600');
+        expect(error.message).toContain('The following directory is outside allowed paths:');
+        expect(error.message).toContain('C\\Invalid\\Path');
+        expect(error.message).toContain('Allowed paths are:');
+        expect(error.message).toContain('C\\Allowed\\Path1, D\\Allowed\\Path2');
+        expect(error.message).toContain('Commands with restricted directory are not allowed to execute');
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary
- fix directory validator tests to match detailed error messages
- update docs for detailed throw comments

## Testing
- `npm test tests/directoryValidator.test.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845f89d0ff88320b33a9d4470fc8753