### PR TITLE
Fix config and path validation tests

### DIFF
--- a/docs/tasks/08-failed-tests-20250613.md
+++ b/docs/tasks/08-failed-tests-20250613.md
@@ -4,13 +4,11 @@ This document lists the Jest tests that were failing as of the latest run. These
 
 ## Summary
 
-- **8 test suites failed**
-- **18 tests failed**
+- **6 test suites failed**
+- **13 tests failed**
 
 ## Failed Tests
 
-- **tests/validation/pathValidation.test.ts**
-  - Path Validation validateWorkingDirectory handles empty allowed paths
 - **tests/server/toolHandlers.test.ts**
   - Tool Handlers set_current_directory tool validates against global allowed paths
 - **tests/server/serverImplementation.test.ts**
@@ -27,11 +25,7 @@ This document lists the Jest tests that were failing as of the latest run. These
 - **tests/processManagement.test.ts**
   - Process Management should handle process spawn errors gracefully
   - Process Management should propagate shell process errors
-- **tests/getConfig.test.ts**
-  - get_config tool createSerializableConfig returns structured configuration
-  - get_config tool createSerializableConfig returns consistent config structure
-  - get_config tool createSerializableConfig handles empty shells config
-  - get_config tool get_config tool response format
+  
 - **tests/errorHandling.test.ts**
   - Error Handling should handle malformed JSON-RPC requests
   - Error Handling should recover from shell crashes

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -5,22 +5,15 @@ import type { ServerConfig, ResolvedShellConfig } from '../types/config.js';
  */
 export function createSerializableConfig(config: ServerConfig): any {
   const serializable: any = {
-    global: {
-      security: {
-        maxCommandLength: config.global.security.maxCommandLength,
-        commandTimeout: config.global.security.commandTimeout,
-        enableInjectionProtection: config.global.security.enableInjectionProtection,
-        restrictWorkingDirectory: config.global.security.restrictWorkingDirectory
-      },
-      restrictions: {
-        blockedCommands: [...config.global.restrictions.blockedCommands],
-        blockedArguments: [...config.global.restrictions.blockedArguments],
-        blockedOperators: [...config.global.restrictions.blockedOperators]
-      },
-      paths: {
-        allowedPaths: [...config.global.paths.allowedPaths],
-        initialDir: config.global.paths.initialDir
-      }
+    security: {
+      maxCommandLength: config.global.security.maxCommandLength,
+      commandTimeout: config.global.security.commandTimeout,
+      enableInjectionProtection: config.global.security.enableInjectionProtection,
+      restrictWorkingDirectory: config.global.security.restrictWorkingDirectory,
+      blockedCommands: [...config.global.restrictions.blockedCommands],
+      blockedArguments: [...config.global.restrictions.blockedArguments],
+      blockedOperators: [...config.global.restrictions.blockedOperators],
+      allowedPaths: [...config.global.paths.allowedPaths]
     },
     shells: {}
   };
@@ -31,52 +24,12 @@ export function createSerializableConfig(config: ServerConfig): any {
 
     const shellInfo: any = {
       enabled: shellConfig.enabled,
-      executable: {
-        command: shellConfig.executable.command,
-        args: [...shellConfig.executable.args]
-      }
+      command: shellConfig.executable.command,
+      args: [...shellConfig.executable.args],
+      blockedOperators: [
+        ...(shellConfig.overrides?.restrictions?.blockedOperators || [])
+      ]
     };
-
-    // Add overrides if present
-    if (shellConfig.overrides) {
-      shellInfo.overrides = {};
-
-      if (shellConfig.overrides.security) {
-        shellInfo.overrides.security = { ...shellConfig.overrides.security };
-      }
-
-      if (shellConfig.overrides.restrictions) {
-        shellInfo.overrides.restrictions = {
-          blockedCommands: shellConfig.overrides.restrictions.blockedCommands ?
-            [...shellConfig.overrides.restrictions.blockedCommands] : undefined,
-          blockedArguments: shellConfig.overrides.restrictions.blockedArguments ?
-            [...shellConfig.overrides.restrictions.blockedArguments] : undefined,
-          blockedOperators: shellConfig.overrides.restrictions.blockedOperators ?
-            [...shellConfig.overrides.restrictions.blockedOperators] : undefined
-        };
-      }
-
-      if (shellConfig.overrides.paths) {
-        shellInfo.overrides.paths = {
-          allowedPaths: shellConfig.overrides.paths.allowedPaths ?
-            [...shellConfig.overrides.paths.allowedPaths] : undefined,
-          initialDir: shellConfig.overrides.paths.initialDir
-        };
-      }
-    }
-
-    // Add WSL-specific config if present
-    if ('wslConfig' in shellConfig && (shellConfig as any).wslConfig) {
-      const wslCfg = (shellConfig as any).wslConfig;
-      shellInfo.wslConfig = {
-        mountPoint: wslCfg.mountPoint,
-        inheritGlobalPaths: wslCfg.inheritGlobalPaths,
-        pathMapping: wslCfg.pathMapping ? {
-          enabled: wslCfg.pathMapping.enabled,
-          windowsToWsl: wslCfg.pathMapping.windowsToWsl
-        } : undefined
-      };
-    }
 
     serializable.shells[shellName] = shellInfo;
   }

--- a/src/utils/pathValidation.ts
+++ b/src/utils/pathValidation.ts
@@ -44,8 +44,10 @@ export function validateWorkingDirectory(
   
   const allowedPaths = context.shellConfig.paths.allowedPaths;
   if (allowedPaths.length === 0) {
-    // When no paths are configured, treat as unrestricted
-    return;
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      `No allowed paths configured for ${context.shellName}`
+    );
   }
   
   // Normalize the directory path for validation


### PR DESCRIPTION
## Summary
- throw error when no allowed paths are configured
- simplify configuration serialization structure
- update failing tests tracking doc

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/validation/pathValidation.test.ts tests/getConfig.test.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684c5cad76ec83208e57afcd6913c8c5